### PR TITLE
Fix delay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,8 @@ visit:
 * https://book.oceaninfohub.org/indexing/qstart.html
 * https://book.oceaninfohub.org/indexing/cliDocker/README.html
 
-For the best documentation on using Gleaner at this time.  
+For the best documentation on using Gleaner at this time.
 
+## Unit tests
+
+There are some unit tests here; to run them, you can do `go test -v ./...`

--- a/cmd/husker/main.go
+++ b/cmd/husker/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gleanerio/gleaner/internal/summoner/acquire"
 
 	"github.com/spf13/viper"
+	bolt "go.etcd.io/bbolt"
 )
 
 var viperVal string
@@ -58,7 +59,14 @@ func main() {
 		buf    bytes.Buffer
 		logger = log.New(&buf, "logger: ", log.Lshortfile)
 	)
-	err = acquire.PageRender(v1, mc, logger, 45*time.Second, url, k)
+	// setup the KV store to hold a record of indexed resources
+	db, err := bolt.Open("gleaner.db", 0600, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	err = acquire.PageRender(v1, mc, logger, 45*time.Second, url, k, db)
 	if err != nil {
 		panic(fmt.Errorf("error when reading config: %v", err))
 	}

--- a/internal/config/sources.go
+++ b/internal/config/sources.go
@@ -194,7 +194,7 @@ func PruneSources(v1 *viper.Viper, useSources []string) (*viper.Viper, error) {
 	var finalSources []Sources
 	allSources, err := GetSources(v1)
 	if err != nil {
-		log.Fatal("error retrieving sources: %s", err)
+		log.Fatal("error retrieving sources: ", err)
 	}
 	for _, s := range allSources {
 		if contains(useSources, s.Name) {

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -240,13 +240,6 @@ func contains(arr []string, str string) bool {
 	return false
 }
 
-func rightPad2Len(s string, padStr string, overallLen int) string {
-	var padCountInt int
-	padCountInt = 1 + ((overallLen - len(padStr)) / len(padStr))
-	var retStr = s + strings.Repeat(padStr, padCountInt)
-	return retStr[:overallLen]
-}
-
 func fileExtensionIsJson(rawUrl string) bool {
 	u, _ := url.Parse(rawUrl)
 	if strings.HasSuffix(u.Path, ".json") || strings.HasSuffix(u.Path, ".jsonld") {

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -40,15 +40,11 @@ func ResRetrieve(v1 *viper.Viper, mc *minio.Client, m map[string][]string, db *b
 func getDomain(v1 *viper.Viper, mc *minio.Client, m map[string][]string, k string, wg *sync.WaitGroup, db *bolt.DB) {
 
 	//// read config file
-	//miniocfg := v1.GetStringMapString("minio")
-	//bucketName := miniocfg["bucket"] //   get the top level bucket for all of gleaner operations from config file
 	bucketName, err := configTypes.GetBucketName(v1)
 
-	//mcfg := v1.GetStringMapString("summoner")
 	var mcfg configTypes.Summoner
 	mcfg, err = configTypes.ReadSummmonerConfig(v1.Sub("summoner"))
-	//tc, err := strconv.ParseInt(mcfg["threads"], 10, 64)
-	tc := mcfg.Threads
+
 	// make the bucket (if it doesn't exist)
 	db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucket([]byte(k))
@@ -58,199 +54,180 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, m map[string][]string, k strin
 		return nil
 	})
 
-	// tc, err := Threadcount(v1)
-	// if err != nil {
-	// 	log.Println(err)
-	// }
-	// dt, err := Delayrequest(v1)
-	// if err != nil {
-	// 	log.Println(err)
-	// }
-
+	tc := mcfg.Threads
 	delay := mcfg.Delay
-	var dt int64
-	//if delay != "" {
+
 	if delay != 0 {
-		//log.Printf("Delay set to: %s milliseconds", delay)
-		//dt, err = strconv.ParseInt(delay, 10, 64)
-		dt = delay
 		if err != nil {
 			log.Println(err)
 			log.Panic("Could not convert delay from config file to a value")
 		}
-		// set threads to 1
-		//log.Println("Delay is not 0, threads set to 1")
 		tc = 1
-	} else {
-		dt = 0
-		if dt > 0 {
-			tc = 1 // If the domain requests a delay between request, drop to single threaded and honor delay
-		}
+	}
 
-		log.Printf("Thread count %d delay %d\n", tc, dt)
+	log.Printf("Thread count %d delay %d\n", tc, delay)
 
-		semaphoreChan := make(chan struct{}, tc) // a blocking channel to keep concurrency under control
-		defer close(semaphoreChan)
-		lwg := sync.WaitGroup{}
+	semaphoreChan := make(chan struct{}, tc) // a blocking channel to keep concurrency under control
+	defer close(semaphoreChan)
+	lwg := sync.WaitGroup{}
 
-		wg.Add(1)       // wg from the calling function
-		defer wg.Done() // tell the wait group that we be done
+	wg.Add(1)       // wg from the calling function
+	defer wg.Done() // tell the wait group that we be done
 
-		count := len(m[k])
-		bar := progressbar.Default(int64(count))
+	count := len(m[k])
+	bar := progressbar.Default(int64(count))
 
-		var (
-			buf    bytes.Buffer
-			logger = log.New(&buf, "logger: ", log.Lshortfile)
-		)
+	var (
+		buf    bytes.Buffer
+		logger = log.New(&buf, "logger: ", log.Lshortfile)
+	)
 
-		// var client http.Client
+	// var client http.Client
 
-		// we actually go get the URLs now
-		for i := range m[k] {
-			lwg.Add(1)
-			urlloc := m[k][i]
+	// we actually go get the URLs now
+	for i := range m[k] {
+		lwg.Add(1)
+		urlloc := m[k][i]
 
-			// TODO / WARNING for large site we can exhaust memory with just the creation of the
-			// go routines. 1 million =~ 4 GB  So we need to control how many routines we
-			// make too..  reference https://github.com/mr51m0n/gorc (but look for someting in the core
-			// library too)
+		// TODO / WARNING for large site we can exhaust memory with just the creation of the
+		// go routines. 1 million =~ 4 GB  So we need to control how many routines we
+		// make too..  reference https://github.com/mr51m0n/gorc (but look for someting in the core
+		// library too)
 
-			// log.Println(urlloc)
+		// log.Println(urlloc)
 
-			go func(i int, k string) {
-				semaphoreChan <- struct{}{}
+		go func(i int, k string) {
+			semaphoreChan <- struct{}{}
 
-				logger.Println(urlloc)
+			logger.Println(urlloc)
 
-				urlloc = strings.ReplaceAll(urlloc, " ", "")
-				urlloc = strings.ReplaceAll(urlloc, "\n", "")
+			urlloc = strings.ReplaceAll(urlloc, " ", "")
+			urlloc = strings.ReplaceAll(urlloc, "\n", "")
 
-				var client http.Client // why do I make this here..  can I use 1 client?  move up in the loop
-				req, err := http.NewRequest("GET", urlloc, nil)
+			var client http.Client // why do I make this here..  can I use 1 client?  move up in the loop
+			req, err := http.NewRequest("GET", urlloc, nil)
+			if err != nil {
+				log.Println(err)
+				logger.Printf("#%d error on %s : %s  ", i, urlloc, err) // print an message containing the index (won't keep order)
+			}
+			req.Header.Set("User-Agent", "EarthCube_DataBot/1.0")
+			req.Header.Set("Accept", "application/ld+json, text/html")
+
+			resp, err := client.Do(req)
+			if err != nil {
+				logger.Printf("#%d error on %s : %s  ", i, urlloc, err) // print an message containing the index (won't keep order)
+				lwg.Done()                                              // tell the wait group that we be done
+				<-semaphoreChan
+				return
+			}
+			defer resp.Body.Close()
+
+			doc, err := goquery.NewDocumentFromResponse(resp)
+			if err != nil {
+				logger.Printf("#%d error on %s : %s  ", i, urlloc, err) // print an message containing the index (won't keep order)
+				lwg.Done()                                              // tell the wait group that we be done
+				<-semaphoreChan
+				return
+			}
+
+			var jsonlds []string
+			var contentTypeHeader = resp.Header["Content-Type"]
+
+			// if
+			// The URL is sending back JSON-LD correctly as application/ld+json
+			// this should not be here IMHO, but need to support people not setting proper header value
+			// The URL is sending back JSON-LD but incorrectly sending as application/json
+			if contains(contentTypeHeader, "application/ld+json") || contains(contentTypeHeader, "application/json") || fileExtensionIsJson(urlloc) {
+				logger.Printf("%s as %s", urlloc, contentTypeHeader)
+				jsonlds, err = addToJsonListIfValid(v1, jsonlds, doc.Text())
 				if err != nil {
-					log.Println(err)
-					logger.Printf("#%d error on %s : %s  ", i, urlloc, err) // print an message containing the index (won't keep order)
+					logger.Printf("Error processing json response from %s: %s", urlloc, err)
 				}
-				req.Header.Set("User-Agent", "EarthCube_DataBot/1.0")
-				req.Header.Set("Accept", "application/ld+json, text/html")
-
-				resp, err := client.Do(req)
-				if err != nil {
-					logger.Printf("#%d error on %s : %s  ", i, urlloc, err) // print an message containing the index (won't keep order)
-					lwg.Done()                                              // tell the wait group that we be done
-					<-semaphoreChan
-					return
-				}
-				defer resp.Body.Close()
-
-				doc, err := goquery.NewDocumentFromResponse(resp)
-				if err != nil {
-					logger.Printf("#%d error on %s : %s  ", i, urlloc, err) // print an message containing the index (won't keep order)
-					lwg.Done()                                              // tell the wait group that we be done
-					<-semaphoreChan
-					return
-				}
-
-				var jsonlds []string
-				var contentTypeHeader = resp.Header["Content-Type"]
-
-				// if
-				// The URL is sending back JSON-LD correctly as application/ld+json
-				// this should not be here IMHO, but need to support people not setting proper header value
-				// The URL is sending back JSON-LD but incorrectly sending as application/json
-				if contains(contentTypeHeader, "application/ld+json") || contains(contentTypeHeader, "application/json") || fileExtensionIsJson(urlloc) {
-					logger.Printf("%s as %s", urlloc, contentTypeHeader)
-					jsonlds, err = addToJsonListIfValid(v1, jsonlds, doc.Text())
+				// look in the HTML page for <script type=application/ld+json>
+			} else {
+				doc.Find("script[type='application/ld+json']").Each(func(i int, s *goquery.Selection) {
+					jsonlds, err = addToJsonListIfValid(v1, jsonlds, s.Text())
 					if err != nil {
-						logger.Printf("Error processing json response from %s: %s", urlloc, err)
+						logger.Printf("Error processing script tag in %s: %s", urlloc, err)
 					}
-					// look in the HTML page for <script type=application/ld+json>
-				} else {
-					doc.Find("script[type='application/ld+json']").Each(func(i int, s *goquery.Selection) {
-						jsonlds, err = addToJsonListIfValid(v1, jsonlds, s.Text())
-						if err != nil {
-							logger.Printf("Error processing script tag in %s: %s", urlloc, err)
-						}
-					})
+				})
+			}
+
+			// For incremental indexing I want to know every URL I visit regardless
+			// if there is a valid JSON-LD document or not.   For "full" indexing we
+			// visit ALL URLs.  However, many will not have JSON-LD, so let's also record
+			// and avoid those during incremental calls.
+
+			// even is no JSON-LD packages found, record the event of checking this URL
+			if len(jsonlds) < 1 {
+				// TODO is her where I then try headless, and scope the following for into an else?
+				log.Printf("Direct access failed, trying headless for  %s ", urlloc)
+				err := PageRender(v1, mc, logger, 60*time.Second, urlloc, k, db) // TODO make delay configurable
+
+				db.Update(func(tx *bolt.Tx) error {
+					b := tx.Bucket([]byte(k))
+					err := b.Put([]byte(urlloc), []byte(fmt.Sprintf("NILL: %s", urlloc))) // no JOSN-LD found at this URL
+					return err
+				})
+				if err != nil {
+					logger.Printf("%s :: %s", urlloc, err)
 				}
 
-				// For incremental indexing I want to know every URL I visit regardless
-				// if there is a valid JSON-LD document or not.   For "full" indexing we
-				// visit ALL URLs.  However, many will not have JSON-LD, so let's also record
-				// and avoid those during incremental calls.
-
-				// even is no JSON-LD packages found, record the event of checking this URL
-				if len(jsonlds) < 1 {
-					// TODO is her where I then try headless, and scope the following for into an else?
-					log.Printf("Direct access failed, trying headless for  %s ", urlloc)
-					err := PageRender(v1, mc, logger, 60*time.Second, urlloc, k, db) // TODO make delay configurable
-
+			} else {
+				log.Printf("Direct access worked for  %s ", urlloc)
+			}
+			for i, jsonld := range jsonlds {
+				if jsonld != "" { // traps out the root domain...   should do this different
+					logger.Printf("#%d Uploading", i)
+					sha, err := Upload(v1, mc, logger, bucketName, k, urlloc, jsonld)
+					if err != nil {
+						logger.Printf("Error uploading jsonld to object store: %s: %s", urlloc, err)
+					}
+					// TODO  Is here where to add an entry to the KV store
 					db.Update(func(tx *bolt.Tx) error {
 						b := tx.Bucket([]byte(k))
-						err := b.Put([]byte(urlloc), []byte(fmt.Sprintf("NILL: %s", urlloc))) // no JOSN-LD found at this URL
+						err := b.Put([]byte(urlloc), []byte(sha))
 						return err
 					})
-					if err != nil {
-						logger.Printf("%s :: %s", urlloc, err)
-					}
-
 				} else {
-					log.Printf("Direct access worked for  %s ", urlloc)
+					logger.Printf("Empty JSON-LD document found. Continuing.")
+					// TODO  Is here where to add an entry to the KV store
+					db.Update(func(tx *bolt.Tx) error {
+						b := tx.Bucket([]byte(k))
+						err := b.Put([]byte(urlloc), []byte(fmt.Sprintf("NULL: %s", urlloc))) // no JOSN-LD found at this URL
+						return err
+					})
 				}
-				for i, jsonld := range jsonlds {
-					if jsonld != "" { // traps out the root domain...   should do this different
-						logger.Printf("#%d Uploading", i)
-						sha, err := Upload(v1, mc, logger, bucketName, k, urlloc, jsonld)
-						if err != nil {
-							logger.Printf("Error uploading jsonld to object store: %s: %s", urlloc, err)
-						}
-						// TODO  Is here where to add an entry to the KV store
-						db.Update(func(tx *bolt.Tx) error {
-							b := tx.Bucket([]byte(k))
-							err := b.Put([]byte(urlloc), []byte(sha))
-							return err
-						})
-					} else {
-						logger.Printf("Empty JSON-LD document found. Continuing.")
-						// TODO  Is here where to add an entry to the KV store
-						db.Update(func(tx *bolt.Tx) error {
-							b := tx.Bucket([]byte(k))
-							err := b.Put([]byte(urlloc), []byte(fmt.Sprintf("NULL: %s", urlloc))) // no JOSN-LD found at this URL
-							return err
-						})
-					}
-				}
+			}
 
-				bar.Add(1)                                       // bar.Incr()
-				logger.Printf("#%d thread for %s ", i, urlloc)   // print an message containing the index (won't keep order)
-				time.Sleep(time.Duration(dt) * time.Millisecond) // sleep a bit if directed to by the provider
+			bar.Add(1)                                       // bar.Incr()
+			logger.Printf("#%d thread for %s ", i, urlloc)   // print an message containing the index (won't keep order)
+			time.Sleep(time.Duration(delay) * time.Millisecond) // sleep a bit if directed to by the provider
 
-				lwg.Done()
+			lwg.Done()
 
-				<-semaphoreChan // clear a spot in the semaphore channel for the next indexing event
-			}(i, k)
-
-		}
-
-		lwg.Wait()
-
-		// TODO write this to minio in the run ID bucket
-		// return the logger buffer or write to a mutex locked bytes buffer
-		f, err := os.Create(fmt.Sprintf("./%s.log", k))
-		if err != nil {
-			log.Println("Error writing a file")
-		}
-
-		w := bufio.NewWriter(f)
-		bc, err := w.WriteString(buf.String())
-		if err != nil {
-			log.Println("Error writing a file")
-		}
-		w.Flush()
-		log.Printf("Wrote log size %d", bc)
+			<-semaphoreChan // clear a spot in the semaphore channel for the next indexing event
+		}(i, k)
 
 	}
+
+	lwg.Wait()
+
+	// TODO write this to minio in the run ID bucket
+	// return the logger buffer or write to a mutex locked bytes buffer
+	f, err := os.Create(fmt.Sprintf("./%s.log", k))
+	if err != nil {
+		log.Println("Error writing a file")
+	}
+
+	w := bufio.NewWriter(f)
+	bc, err := w.WriteString(buf.String())
+	if err != nil {
+		log.Println("Error writing a file")
+	}
+	w.Flush()
+	log.Printf("Wrote log size %d", bc)
+
 }
 
 func contains(arr []string, str string) bool {

--- a/internal/summoner/acquire/acquire_test.go
+++ b/internal/summoner/acquire/acquire_test.go
@@ -1,0 +1,55 @@
+package acquire
+
+import
+(
+    "testing"
+    "github.com/stretchr/testify/assert"
+    "github.com/spf13/viper"
+)
+
+func TestGetConfig(t *testing.T) {
+	t.Run("It reads a config and returns the expected information", func(t *testing.T) {
+		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": "0"}}
+
+		var viper = viper.New()
+		for key, value := range conf {
+			viper.Set(key, value)
+		}
+
+		bucketName, tc, delay, err := getConfig(viper)
+		assert.Equal(t, "test", bucketName)
+		assert.Equal(t, 5, tc)
+		assert.Equal(t, int64(0), delay)
+		assert.Nil(t, err)
+	})
+
+	t.Run("It sets the thread count to 1 if a delay is specified", func(t *testing.T) {
+		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": "1000"}}
+
+		var viper = viper.New()
+		for key, value := range conf {
+			viper.Set(key, value)
+		}
+
+		bucketName, tc, delay, err := getConfig(viper)
+		assert.Equal(t, "test", bucketName)
+		assert.Equal(t, 1, tc)
+		assert.Equal(t, int64(1000), delay)
+		assert.Nil(t, err)
+	})
+
+	t.Run("It allows delay to be optional", func(t *testing.T) {
+		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5"}}
+
+		var viper = viper.New()
+		for key, value := range conf {
+			viper.Set(key, value)
+		}
+
+		bucketName, tc, delay, err := getConfig(viper)
+		assert.Equal(t, "test", bucketName)
+		assert.Equal(t, 5, tc)
+		assert.Equal(t, int64(0), delay)
+		assert.Nil(t, err)
+	})
+}

--- a/internal/summoner/acquire/googledrive.go
+++ b/internal/summoner/acquire/googledrive.go
@@ -302,7 +302,7 @@ func GetFromGDrive(mc *minio.Client, v1 *viper.Viper) (string, error) {
 		}
 	}
 	var count = len(results)
-	m := fmt.Sprintf("GoogleDrives %f files processed", count)
+	m := fmt.Sprintf("GoogleDrives %d files processed", count)
 	return m, err
 }
 

--- a/internal/summoner/acquire/jsonutils_test.go
+++ b/internal/summoner/acquire/jsonutils_test.go
@@ -26,12 +26,12 @@ var v1 = viper.New()
 func TestIsValid(t *testing.T) {
     t.Run("It returns true for valid JSON-LD", func(t *testing.T) {
         result, err := isValid(v1, validJson)
-        assert.Equal(t, result, true)
+        assert.Equal(t, true, result)
         assert.Nil(t, err)
     })
     t.Run("It returns false and throws an error for invalid JSON-LD", func(t *testing.T) {
         result, err := isValid(v1, invalidJson)
-        assert.Equal(t, result, false)
+        assert.Equal(t, false, result)
         assert.NotNil(t, err)
     })
 
@@ -43,12 +43,12 @@ func TestAddToJsonListIfValid(t *testing.T) {
 
     t.Run("It appends valid json to the array", func(t *testing.T) {
         result, err := addToJsonListIfValid(v1, original, validJson)
-        assert.Equal(t, result, []string{"test", validJson})
+        assert.Equal(t, []string{"test", validJson}, result)
         assert.Nil(t, err)
     })
     t.Run("It does not append invalid json to the array", func(t *testing.T) {
         result, err := addToJsonListIfValid(v1, original, invalidJson)
-        assert.Equal(t, result, original)
+        assert.Equal(t, original, result)
         assert.NotNil(t, err)
     })
 }

--- a/tools/boltminio/main.go
+++ b/tools/boltminio/main.go
@@ -68,8 +68,13 @@ func main() {
 	// read config file
 	miniocfg := v1.GetStringMapString("minio")
 	bucketName := miniocfg["bucket"] //   get the top level bucket for all of gleaner operations from config file
+	db, err := bolt.Open("my.db", 0600, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	ru := acquire.ResourceURLs(v1, mc, false)
+	defer db.Close()
+	ru := acquire.ResourceURLs(v1, mc, false, db)
 	// hru := acquire.ResourceURLs(v1, true)
 	// log.Println(len(ru["samplesearth"].URL))
 	// log.Println(len(hru["samplesearth"].URL))
@@ -104,13 +109,6 @@ func main() {
 	for k := range diff {
 		fmt.Println(diff[k])
 	}
-
-	db, err := bolt.Open("my.db", 0600, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	defer db.Close()
 
 }
 

--- a/tools/cdp/main.go
+++ b/tools/cdp/main.go
@@ -119,7 +119,7 @@ func run(timeout time.Duration) error {
 		return err
 	}
 
-	fmt.Printf("HTML: %s\n", len(result.OuterHTML))
+	fmt.Printf("HTML: %d\n", len(result.OuterHTML))
 
 	return nil
 }

--- a/tools/siteprovdiff/main.go
+++ b/tools/siteprovdiff/main.go
@@ -73,7 +73,6 @@ func main() {
 		log.Fatal(err)
 	}
 	defer db.Close()
-	summoner.Summoner(mc, v1, db)
 	ru := acquire.ResourceURLs(v1, mc, false, db)
 	// hru := acquire.ResourceURLs(v1, true)
 	// log.Println(len(ru["samplesearth"].URL))

--- a/tools/siteprovdiff/main.go
+++ b/tools/siteprovdiff/main.go
@@ -11,6 +11,8 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/spf13/viper"
+	bolt "go.etcd.io/bbolt"
+
 )
 
 var viperVal string
@@ -65,8 +67,14 @@ func main() {
 	// read config file
 	miniocfg := v1.GetStringMapString("minio")
 	bucketName := miniocfg["bucket"] //   get the top level bucket for all of gleaner operations from config file
-
-	ru := acquire.ResourceURLs(v1, mc, false)
+	// setup the KV store to hold a record of indexed resources
+	db, err := bolt.Open("gleaner.db", 0600, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	summoner.Summoner(mc, v1, db)
+	ru := acquire.ResourceURLs(v1, mc, false, db)
 	// hru := acquire.ResourceURLs(v1, true)
 	// log.Println(len(ru["samplesearth"].URL))
 	// log.Println(len(hru["samplesearth"].URL))


### PR DESCRIPTION
This is a step on the way to doing https://github.com/gleanerio/gleaner/issues/27

While looking into indexing options, I noticed that no files were summoned when I specified a delay in the gleaner config yaml. I realized that this was because of a code branching error - the `if` statement branch that sets the thread count to 1 if a delay is specified accidentally bypassed the rest of the summoner code.

This fix closes that metaphorical curly brace and adds tests for the delay / thread count interaction logic.