### PR TITLE
Add robots.txt support

### DIFF
--- a/docs/README_Configure_Template.md
+++ b/docs/README_Configure_Template.md
@@ -189,8 +189,7 @@ The miller and summon sections are true and we will leave them that way.  It mea
 Now look at the "miller:"  section when lets of pick what milling to do.   Currently it is set with only graph set to true.  Let's leave it that way for now.  This means Gleaner will only attempt to make graph and not also run validation or generate prov reports for the process.  
 
 The final section we need to look at is the "sources:" section.   
-Here is where the fun is.  While there are two types, sitegraph and sitemaps we will normally use sitemap type. 
-There is a third type that involves configuring and pulling from a
+Here is where the fun is.  While the most common type of source is a `sitemap`, there are other types available, and examples of each are below.
 
 A standard [sitemap](./SourceSitemap.md) is below:
 ```yaml
@@ -234,6 +233,23 @@ sources:
   active: true
   credentialsfile: configs/credentials/gleaner-331805-030e15e1d9c4.json
   other: {}
+```
+
+A csv
+```
+TODO: I know this exists but I don't know what it looks like
+```
+
+A robots.txt url (which can have links to multiple sitemaps)
+```yaml
+sources:
+- name: npdc
+  sourcetype: robots
+  headless: false
+  url: https://npdc.nl/robots.txt
+  properName: Netherlands Polar Data Center
+  domain: https://npdc.nl
+  active: false
 ```
 These are the sources we wish to pull and process. 
 Each source has a type, and 8 entries though at this time we no longer use the "logo" value. 

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/boltdb/bolt v1.3.1
 	github.com/gleanerio/nabu v0.0.0-20211107193830-958398c3aaef
 	github.com/oxffaa/gopher-parse-sitemap v0.0.0-20191021113419-005d2eb1def4
+	github.com/samclarke/robotstxt v0.0.0-20171127213916-2817654b7988
 	github.com/tidwall/gjson v1.10.2
 	github.com/tidwall/sjson v1.2.3
 	github.com/utahta/go-openuri v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -480,6 +480,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.1.0/go.mod h1:B/mN0msZuINBtQ1zZLEQcegFJJf9vnYIR88KRMEuODE=
+github.com/samclarke/robotstxt v0.0.0-20171127213916-2817654b7988 h1:zFAgZ1xCwUizjAl1AUz7aLBulEHoSv+ew+RffLCWhBA=
+github.com/samclarke/robotstxt v0.0.0-20171127213916-2817654b7988/go.mod h1:XvytvkE1sPYD7U4AZzyWVJOsVTZuIDqFq+R5KKwy0Q0=
 github.com/schollz/progressbar v1.0.0 h1:gbyFReLHDkZo8mxy/dLWMr+Mpb1MokGJ1FqCiqacjZM=
 github.com/schollz/progressbar v1.0.0/go.mod h1:/l9I7PC3L3erOuz54ghIRKUEFcosiWfLvJv+Eq26UMs=
 github.com/schollz/progressbar/v3 v3.8.3 h1:FnLGl3ewlDUP+YdSwveXBaXs053Mem/du+wr7XSYKl8=

--- a/internal/config/sources.go
+++ b/internal/config/sources.go
@@ -15,6 +15,7 @@ import (
 
 // as read from csv
 type Sources struct {
+	// Valid values for SourceType: sitemap, sitegraph, csv, googledrive, and robots
 	SourceType      string `default:"sitemap"`
 	Name            string
 	Logo            string
@@ -161,6 +162,17 @@ func GetActiveSourceByType(sources []Sources, key string) []Sources {
 	}
 	return sourcesSlice
 }
+
+func GetActiveSourceByHeadless(sources []Sources, headless bool) []Sources {
+	var sourcesSlice []Sources
+	for _, s := range sources {
+		if s.Headless == headless && s.Active == true {
+			sourcesSlice = append(sourcesSlice, s)
+		}
+	}
+	return sourcesSlice
+}
+
 
 func GetSourceByName(sources []Sources, name string) (Sources, error) {
 	for _, s := range sources {

--- a/internal/config/sources.go
+++ b/internal/config/sources.go
@@ -162,6 +162,15 @@ func GetActiveSourceByType(sources []Sources, key string) []Sources {
 	return sourcesSlice
 }
 
+func GetSourceByName(sources []Sources, name string) (Sources, error) {
+	for _, s := range sources {
+		if s.Name == name {
+			return s, nil
+		}
+	}
+	return Sources{}, fmt.Errorf("Unable to find a source with name %s", name)
+}
+
 func SourceToNabuPrefix(sources []Sources, includeProv bool) []string {
 
 	var prefixes []string

--- a/internal/config/sources_test.go
+++ b/internal/config/sources_test.go
@@ -1,0 +1,182 @@
+package config
+
+import
+(
+    "testing"
+    "github.com/stretchr/testify/assert"
+)
+
+var sources = []Sources{
+	{
+		Name: "test1",
+		Headless: true,
+		Active: true,
+		SourceType: "sitemap",
+	},
+	{
+		Name: "test2",
+		Headless: false,
+		Active: true,
+		SourceType: "robots",
+	},
+	{
+		Name: "test3",
+		Headless: false,
+		Active: false,
+		SourceType: "sitemap",
+	},
+	{
+		Name: "test4",
+		Headless: true,
+		Active: false,
+		SourceType: "sitemap",
+	},
+}
+
+var empty = []Sources{}
+
+func TestGetSourceByType(t *testing.T) {
+	t.Run("It gets sources of the given type", func(t *testing.T) {
+	expected := []Sources{
+		{
+			Name: "test1",
+			Headless: true,
+			Active: true,
+			SourceType: "sitemap",
+		},
+		{
+			Name: "test3",
+			Headless: false,
+			Active: false,
+			SourceType: "sitemap",
+		},
+		{
+			Name: "test4",
+			Headless: true,
+			Active: false,
+			SourceType: "sitemap",
+		},
+	}
+		results := GetSourceByType(sources, "sitemap")
+		assert.ElementsMatch(t, expected, results)
+	})
+
+	t.Run("It returns an empty slice if there are no such sources", func(t *testing.T) {
+		results := GetSourceByType(sources, "csv")
+		assert.ElementsMatch(t, empty, results)
+	})
+
+	t.Run("It handles an empty source slice correctly", func(t *testing.T){
+		results := GetSourceByType(empty, "sitemap")
+		assert.ElementsMatch(t, empty, results)
+	})
+}
+
+func TestGetActiveSourceByType(t *testing.T) {
+	t.Run("It gets active sources of the given type", func(t *testing.T) {
+		expected := []Sources{
+			{
+				Name: "test1",
+				Headless: true,
+				Active: true,
+				SourceType: "sitemap",
+			},
+		}
+		results := GetActiveSourceByType(sources, "sitemap")
+		assert.ElementsMatch(t, expected, results)
+	})
+
+	t.Run("It returns an empty slice if there are no such sources", func(t *testing.T) {
+		results := GetActiveSourceByType(sources, "csv")
+		assert.ElementsMatch(t, empty, results)
+	})
+
+	t.Run("It handles an empty source slice correctly", func(t *testing.T){
+		results := GetActiveSourceByType(empty, "sitemap")
+		assert.ElementsMatch(t, empty, results)
+	})
+}
+
+func TestGetActiveSourceByHeadless(t *testing.T) {
+	t.Run("It gets active sources of the given type", func(t *testing.T) {
+		expectedTrue := []Sources{
+			{
+				Name: "test1",
+				Headless: true,
+				Active: true,
+				SourceType: "sitemap",
+			},
+		}
+		results := GetActiveSourceByHeadless(sources, true)
+		assert.ElementsMatch(t, expectedTrue, results)
+
+		expectedFalse := []Sources{
+			{
+				Name: "test2",
+				Headless: false,
+				Active: true,
+				SourceType: "robots",
+			},
+		}
+		results = GetActiveSourceByHeadless(sources, false)
+		assert.ElementsMatch(t, expectedFalse, results)
+	})
+
+	t.Run("It returns an empty slice if there are no such sources", func(t *testing.T) {
+		test := []Sources{
+		{
+			Name: "test1",
+			Headless: true,
+			Active: true,
+			SourceType: "sitemap",
+		},
+		{
+			Name: "test3",
+			Headless: false,
+			Active: false,
+			SourceType: "sitemap",
+		},
+		{
+			Name: "test4",
+			Headless: true,
+			Active: false,
+			SourceType: "sitemap",
+		},
+	}
+		results := GetActiveSourceByHeadless(test, false)
+		assert.ElementsMatch(t, empty, results)
+	})
+
+	t.Run("It handles an empty source slice correctly", func(t *testing.T){
+		results := GetActiveSourceByHeadless(empty, true)
+		assert.ElementsMatch(t, empty, results)
+	})
+}
+
+func TestGetSourceByName(t *testing.T) {
+	t.Run("It gets sources of the given name", func(t *testing.T) {
+		expected := Sources{
+			Name: "test1",
+			Headless: true,
+			Active: true,
+			SourceType: "sitemap",
+		}
+
+		results, err := GetSourceByName(sources, "test1")
+		assert.EqualValues(t, expected, results)
+		assert.Nil(t, err)
+
+	})
+
+	t.Run("It returns an empty slice if there are no such sources", func(t *testing.T) {
+		results, err := GetSourceByName(sources, "test99")
+		assert.ElementsMatch(t, empty, results)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("It handles an empty source slice correctly", func(t *testing.T){
+		results, err := GetSourceByName(empty, "test1")
+		assert.ElementsMatch(t, empty, results)
+		assert.NotNil(t, err)
+	})
+}

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -36,7 +36,6 @@ func ResRetrieve(v1 *viper.Viper, mc *minio.Client, m map[string][]string, db *b
 		go getDomain(v1, mc, urls, domain, &wg, db)
 	}
 
-	time.Sleep(2 * time.Second) // ?? why is this here?
 	wg.Wait()
 }
 

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -139,19 +139,17 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 
 
 	// we actually go get the URLs now
-	for i, urlloc := range urls {
+	for i := range urls {
 		lwg.Add(1)
+		urlloc := urls[i]
 
 		// TODO / WARNING for large site we can exhaust memory with just the creation of the
 		// go routines. 1 million =~ 4 GB  So we need to control how many routines we
 		// make too..  reference https://github.com/mr51m0n/gorc (but look for someting in the core
 		// library too)
 
-		// log.Println(urlloc)
-
 		go func(i int, sourceName string) {
 			semaphoreChan <- struct{}{}
-
 			logger.Println("Indexing", urlloc)
 
 			urlloc = strings.ReplaceAll(urlloc, " ", "")

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -156,9 +156,12 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 			urlloc = strings.ReplaceAll(urlloc, "\n", "")
 
 			if robots != nil {
-			    allowed, _ := robots.IsAllowed(EarthCubeAgent, urlloc)
+			    allowed, err := robots.IsAllowed(EarthCubeAgent, urlloc)
 			    if !allowed {
-			        logger.Printf("Declining to index %s because it is disallowed by robots.txt", urlloc)
+			        logger.Printf("Declining to index %s because it is disallowed by robots.txt. Error information, if any: %s", urlloc, err)
+			        lwg.Done()                                              // tell the wait group that we be done
+					<-semaphoreChan
+			        return
 			    }
 			}
 

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -71,7 +71,12 @@ func getRobotsForDomain(v1 *viper.Viper, sourceName string) (*robotstxt.RobotsTx
 		return nil, err
 	}
 
-	robotsUrl := domain.Domain + "/robots.txt"
+	var robotsUrl string
+	if domain.SourceType == "robots" {
+		robotsUrl = domain.URL
+	} else {
+		robotsUrl = domain.Domain + "/robots.txt"
+	}
 
 	robots, err := getRobotsTxt(robotsUrl)
 	if err != nil {

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -41,7 +41,6 @@ func ResRetrieve(v1 *viper.Viper, mc *minio.Client, m map[string][]string, db *b
 
 func getConfig(v1 *viper.Viper)(string, int, int64, error) {
 	bucketName, err := configTypes.GetBucketName(v1)
-	fmt.Println(bucketName, err)
 	if err != nil {
 		return bucketName, 0, 0, err
 	}

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -89,19 +89,19 @@ func getDomainCrawlDelay(v1 *viper.Viper, sourceName string)(int64) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Printf("error fetching robots.txt for %s : %s  ", domain, err)
+		log.Printf("error fetching robots.txt at %s : %s  ", robotsUrl, err)
 		return 0
 	}
 	defer resp.Body.Close()
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Printf("error reading response for robots.txt from %s : %s ", domain, err)
+		log.Printf("error reading response for robots.txt at %s : %s ", robotsUrl, err)
 		return 0
 	}
 
 	robots, err := robotstxt.Parse(string(bodyBytes), robotsUrl)
 	if err != nil {
-		log.Printf("error parsing robots.txt for %s : %s  ", domain, err)
+		log.Printf("error parsing robots.txt at %s : %s  ", robotsUrl, err)
 		return 0
 	}
 

--- a/internal/summoner/acquire/acquire_test.go
+++ b/internal/summoner/acquire/acquire_test.go
@@ -79,13 +79,14 @@ func TestGetDomainCrawlDelay(t *testing.T) {
 	for key, value := range conf {
 		viper.Set(key, value)
 	}
+	var client http.Client
 
 	t.Run("It returns the crawl delay when specified", func(t *testing.T) {
-		assert.Equal(t, int64(10000), getDomainCrawlDelay(viper, "test"))
+		assert.Equal(t, int64(10000), getDomainCrawlDelay(viper, "test", client))
 	})
 
 	t.Run("It returns 0 if there is an error", func(t *testing.T) {
-		assert.Equal(t, int64(0), getDomainCrawlDelay(viper, "bad-value"))
+		assert.Equal(t, int64(0), getDomainCrawlDelay(viper, "bad-value", client))
 	})
 
 }

--- a/internal/summoner/acquire/acquire_test.go
+++ b/internal/summoner/acquire/acquire_test.go
@@ -56,7 +56,7 @@ func TestGetConfig(t *testing.T) {
 	})
 }
 
-func TestGetDomainCrawlDelay(t *testing.T) {
+func TestGetRobotsForDomain(t *testing.T) {
 	var robots = `User-agent: *
 		Disallow: /cgi-bin
 		Disallow: /forms
@@ -79,14 +79,17 @@ func TestGetDomainCrawlDelay(t *testing.T) {
 	for key, value := range conf {
 		viper.Set(key, value)
 	}
-	var client http.Client
 
-	t.Run("It returns the crawl delay when specified", func(t *testing.T) {
-		assert.Equal(t, int64(10000), getDomainCrawlDelay(viper, "test", client))
+	t.Run("It returns an object representing robots.txt when specified", func(t *testing.T) {
+		robots, err := getRobotsForDomain(viper, "test")
+		assert.NotNil(t, robots)
+		assert.Nil(t, err)
 	})
 
-	t.Run("It returns 0 if there is an error", func(t *testing.T) {
-		assert.Equal(t, int64(0), getDomainCrawlDelay(viper, "bad-value", client))
+	t.Run("It returns nil if there is an error", func(t *testing.T) {
+		robots, err := getRobotsForDomain(viper, "bad-value")
+		assert.Nil(t, robots)
+		assert.NotNil(t, err)
 	})
 
 }

--- a/internal/summoner/acquire/resources.go
+++ b/internal/summoner/acquire/resources.go
@@ -84,7 +84,6 @@ func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB)
 			urls = excludeAlreadySummoned(mapname, urls, db)
 		}
 		m[mapname] = urls
-		m[mapname] = urls
 		log.Printf("%s sitemap size from robots.txt is : %d mode: %s \n", mapname, len(m[mapname]),  mcfg.Mode)
 	}
 

--- a/internal/summoner/acquire/resources.go
+++ b/internal/summoner/acquire/resources.go
@@ -27,131 +27,131 @@ import (
 // }
 //type Sources = configTypes.Sources
 const siteMapType = "sitemap"
+const robotsType = "robots"
 
 // ResourceURLs looks gets the resource URLs for a domain.  The results is a
 // map with domain name as key and []string of the URLs to process.
-func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB) map[string][]string {
-	// read config file
-	//miniocfg := v1.GetStringMapString("minio")
-	//bucketName := miniocfg["bucket"] //   get the top level bucket for all of gleaner operations from config file
-	// bucketName, err := configTypes.GetBucketName(v1) //   get the top level bucket for all of gleaner operations from config file
+func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB) (map[string][]string, error) {
 
 	m := make(map[string][]string) // make a map
 
-	//var domains []Sources
-	//err := v1.UnmarshalKey("sources", &domains)
+	// Know whether we are running in diff mode, in order to exclude urls that have already
+	// been summoned before
+	mcfg, err := configTypes.ReadSummmonerConfig(v1.Sub("summoner"))
 	domains, err := configTypes.GetSources(v1)
-	log.Println(domains)
-	domains = configTypes.GetActiveSourceByType(domains, siteMapType)
+	domains = configTypes.GetActiveSourceByHeadless(domains, headless)
 	if err != nil {
-		log.Println(err)
+		log.Println("Error getting sources to summon: ", err)
+		return m, err
 	}
-	log.Println(domains)
 
-	//mcfg := v1.GetStringMapString("summoner")
-	var mcfg configTypes.Summoner
-	mcfg, err = configTypes.ReadSummmonerConfig(v1.Sub("summoner"))
+	sitemapDomains := configTypes.GetActiveSourceByType(domains, siteMapType)
 
-	for k := range domains {
-		if headless == domains[k].Headless {
-			mapname := domains[k].Name // TODO I would like to use this....
+	for _, domain := range sitemapDomains {
+		mapname := domain.Name // TODO I would like to use this....
+		urls, err := getSitemapURLList(domain.URL)
+		if err != nil {
+			log.Println("Error getting sitemap urls for: ", mapname, err)
+			return m, err
+		}
+		if mcfg.Mode == "diff" {
+			urls = excludeAlreadySummoned(mapname, urls, db)
+		}
+		m[mapname] = urls
+		log.Printf("%s sitemap size is : %d mode: %s \n", mapname, len(m[mapname]),  mcfg.Mode)
+	}
+
+	robotsDomains := configTypes.GetActiveSourceByType(domains, robotsType)
+
+	for _, domain := range robotsDomains {
+		mapname := domain.Name
+		// first, get the robots file and parse it
+	}
+
+	// todo now do the same, except for robots domains - get the sitemaps out of those text files
+	// and exclude excluded path urls
+
+	log.Println(m)
+	return m, nil
+}
+
+// given a sitemap url, parse it and get the list of URLS from it.
+func getSitemapURLList(domainURL string) ([]string, error) {
+	var us sitemaps.Sitemap
+	var s []string
+
+	idxr, err := sitemaps.DomainIndex(domainURL)
+	if err != nil {
+		log.Println("Error reading sitemap at:", domainURL, err)
+		return s, err
+	}
+
+	if len(idxr) < 1 {
+		log.Println(domainURL, "is not a sitemap index, checking to see if it is a sitemap")
+		us, err = sitemaps.DomainSitemap(domainURL)
+		if err != nil {
+			log.Println("Error parsing sitemap index at ", domainURL, err)
+			return s, err
+		}
+	} else {
+		log.Println("Walking the sitemap index for sitemaps")
+		for _, idxv := range idxr {
+			subset, err := sitemaps.DomainSitemap(idxv)
+			us.URL = append(us.URL, subset.URL...)
 			if err != nil {
-				log.Println(domains[k].Name, "Error in domain parsing", err)
+				log.Println("Error parsing sitemap index at:", idxv, err)
+				return s, err
 			}
+		}
+	}
+	// if mcfg["after"] != "" {
+	// 	//log.Println("Get After Date")
+	// 	us, err = sitemaps.GetAfterDate(domain.URL, nil, mcfg["after"])
+	// 	if err != nil {
+	// 		log.Println(domains[k].Name, err)
+	// 		// pass back error and deal with it better in the logs
+	// 		// and in the user experience
+	// 	}
+	// } else {
+	// 	//log.Println("Get with no date")
+	// 	us, err = sitemaps.Get(domains[k].URL, nil)
+	// 	if err != nil {
+	// 		log.Println(domains[k].Name, err)
+	// 		// pass back error and deal with it better in the logs
+	// 		// and in the user experience
+	// 	}
+	// }
 
-			// log.Println(mcfg)
-
-			var us sitemaps.Sitemap
-
-			idxr, err := sitemaps.DomainIndex(domains[k].URL)
-			if err != nil {
-				log.Println("Error reading this source")
-				log.Println(err)
-				// os.Exit(0)  // TODO this function needs to return an error and talk with others
-			}
-
-			if len(idxr) < 1 {
-				log.Println("We are not a sitemap index, check to see if we are a sitemap")
-				us, err = sitemaps.DomainSitemap(domains[k].URL)
-				if err != nil {
-					fmt.Println(err)
-				}
-			} else {
-				log.Println("Walk the sitemap index for sitemaps")
-				for _, idxv := range idxr {
-					subset, err := sitemaps.DomainSitemap(idxv)
-					us.URL = append(us.URL, subset.URL...)
-					if err != nil {
-						fmt.Println(err)
-					}
-				}
-			}
-
-			// if mcfg["after"] != "" {
-			// 	//log.Println("Get After Date")
-			// 	us, err = sitemaps.GetAfterDate(domains[k].URL, nil, mcfg["after"])
-			// 	if err != nil {
-			// 		log.Println(domains[k].Name, err)
-			// 		// pass back error and deal with it better in the logs
-			// 		// and in the user experience
-			// 	}
-			// } else {
-			// 	//log.Println("Get with no date")
-			// 	us, err = sitemaps.Get(domains[k].URL, nil)
-			// 	if err != nil {
-			// 		log.Println(domains[k].Name, err)
-			// 		// pass back error and deal with it better in the logs
-			// 		// and in the user experience
-			// 	}
-			// }
-
-			// Convert the array of sitemap package struct to simply the URLs in []string
-			var s []string
-			for k := range us.URL {
-				if us.URL[k].Loc != "" { // TODO why did this otherwise add a nil to the array..  need to check
-					s = append(s, strings.TrimSpace(us.URL[k].Loc))
-				}
-			}
-
-			//  TODO if we check for URLs in prov..  do that here..
-			if mcfg.Mode == "diff" {
-				//oa := objects.ProvURLs(v1, mc, bucketName, fmt.Sprintf("prov/%s", mapname))
-
-				oa := []string{}
-				db.View(func(tx *bolt.Tx) error {
-					// Assume bucket exists and has keys
-					b := tx.Bucket([]byte(domains[k].Name))
-					c := b.Cursor()
-
-					for key, _ := c.First(); key != nil; key, _ = c.Next() {
-						//fmt.Printf("key=%s, value=%s\n", k, v)
-						oa = append(oa, fmt.Sprintf("%s", key))
-					}
-
-					return nil
-				})
-
-				d := difference(s, oa)
-				m[mapname] = d
-			} else {
-				m[mapname] = s
-			}
-
-			//  TODO if we check for URLs in prov..  do that here..
-			//if mcfg["mode"] == "diff" {
-			//oa := objects.ProvURLs(v1, mc, bucketName, fmt.Sprintf("prov/%s", mapname))
-			//d := difference(s, oa)
-			//m[mapname] = d
-			//} else {
-			//m[mapname] = s
-			//}
-
-			log.Printf("%s sitemap size is : %d queuing: %d mode: %s \n", domains[k].Name, len(s), len(m[mapname]), mcfg.Mode)
-
+	// Convert the array of sitemap package struct to simply the URLs in []string
+	for _, urlStruct := range us.URL {
+		if urlStruct.Loc != "" { // TODO why did this otherwise add a nil to the array..  need to check
+			s = append(s, strings.TrimSpace(urlStruct.Loc))
 		}
 	}
 
-	return m
+	return s, nil
+}
+
+func excludeAlreadySummoned(domainName string, urls []string, db *bolt.DB) []string {
+	//  TODO if we check for URLs in prov..  do that here..
+	//oa := objects.ProvURLs(v1, mc, bucketName, fmt.Sprintf("prov/%s", mapname))
+
+	oa := []string{}
+	db.View(func(tx *bolt.Tx) error {
+		// Assume bucket exists and has keys
+		b := tx.Bucket([]byte(domainName))
+		c := b.Cursor()
+
+		for key, _ := c.First(); key != nil; key, _ = c.Next() {
+			//fmt.Printf("key=%s, value=%s\n", k, v)
+			oa = append(oa, fmt.Sprintf("%s", key))
+		}
+
+		return nil
+	})
+
+	d := difference(urls, oa)
+	return d
 }
 
 // difference returns the elements in `a` that aren't in `b`.

--- a/internal/summoner/acquire/resources.go
+++ b/internal/summoner/acquire/resources.go
@@ -88,10 +88,6 @@ func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB)
 		log.Printf("%s sitemap size from robots.txt is : %d mode: %s \n", mapname, len(m[mapname]),  mcfg.Mode)
 	}
 
-	// todo now do the same, except for robots domains - get the sitemaps out of those text files
-	// and exclude excluded path urls
-
-	log.Println(m)
 	return m, nil
 }
 

--- a/internal/summoner/acquire/utils.go
+++ b/internal/summoner/acquire/utils.go
@@ -7,33 +7,33 @@ import (
     "github.com/samclarke/robotstxt"
 )
 
-func getRobotsTxt(robotsUrl string) (robotstxt, error) {
+func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsTxt, error) {
 	var client http.Client
-	var robots robotstxt.RobotsTxt
+
     req, err := http.NewRequest("GET", robotsUrl, nil)
     if err != nil {
         log.Printf("error creating http request: %s  ",  err)
-        return robots, err
+        return nil, err
     }
-    req.Header.Set("User-Agent", "EarthCube_DataBot/1.0")
+    req.Header.Set("User-Agent", EarthCubeAgent)
     req.Header.Set("Accept", "text/plain, text/html")
 
     resp, err := client.Do(req)
     if err != nil {
         log.Printf("error fetching robots.txt at %s : %s  ", robotsUrl, err)
-        return robots, err
+        return nil, err
     }
     defer resp.Body.Close()
     bodyBytes, err := ioutil.ReadAll(resp.Body)
     if err != nil {
         log.Printf("error reading response for robots.txt at %s : %s ", robotsUrl, err)
-        return robots, err
+        return nil, err
     }
 
-    robots, err = robotstxt.Parse(string(bodyBytes), robotsUrl)
+    robots, err := robotstxt.Parse(string(bodyBytes), robotsUrl)
     if err != nil {
         log.Printf("error parsing robots.txt at %s : %s  ", robotsUrl, err)
-        return robots, err
+        return nil, err
     }
 
     return robots, nil

--- a/internal/summoner/acquire/utils.go
+++ b/internal/summoner/acquire/utils.go
@@ -1,0 +1,40 @@
+package acquire
+
+import (
+	"log"
+    "net/http"
+    "io/ioutil"
+    "github.com/samclarke/robotstxt"
+)
+
+func getRobotsTxt(robotsUrl string) (robotstxt, error) {
+	var client http.Client
+	var robots robotstxt.RobotsTxt
+    req, err := http.NewRequest("GET", robotsUrl, nil)
+    if err != nil {
+        log.Printf("error creating http request: %s  ",  err)
+        return robots, err
+    }
+    req.Header.Set("User-Agent", "EarthCube_DataBot/1.0")
+    req.Header.Set("Accept", "text/plain, text/html")
+
+    resp, err := client.Do(req)
+    if err != nil {
+        log.Printf("error fetching robots.txt at %s : %s  ", robotsUrl, err)
+        return robots, err
+    }
+    defer resp.Body.Close()
+    bodyBytes, err := ioutil.ReadAll(resp.Body)
+    if err != nil {
+        log.Printf("error reading response for robots.txt at %s : %s ", robotsUrl, err)
+        return robots, err
+    }
+
+    robots, err = robotstxt.Parse(string(bodyBytes), robotsUrl)
+    if err != nil {
+        log.Printf("error parsing robots.txt at %s : %s  ", robotsUrl, err)
+        return robots, err
+    }
+
+    return robots, nil
+}

--- a/internal/summoner/summoner.go
+++ b/internal/summoner/summoner.go
@@ -22,14 +22,14 @@ func Summoner(mc *minio.Client, v1 *viper.Viper, db *bolt.DB) {
 	if err != nil {
 		log.Printf("Error getting urls that do not require headless processing: %s", err)
 	} else if len(ru) > 0 {
-		//acquire.ResRetrieve(v1, mc, ru, db) // TODO  These can be go funcs that run all at the same time..
+		acquire.ResRetrieve(v1, mc, ru, db) // TODO  These can be go funcs that run all at the same time..
 	}
 	hru, err := acquire.ResourceURLs(v1, mc, true, db)
 
 	if err != nil {
 		log.Printf("Error getting urls that require headless processing: %s", err)
 	} else if len(hru) > 0 {
-		//acquire.HeadlessNG(v1, mc, hru, db)
+		acquire.HeadlessNG(v1, mc, hru, db)
 	}
 
 	// Time report

--- a/internal/summoner/summoner.go
+++ b/internal/summoner/summoner.go
@@ -16,17 +16,20 @@ func Summoner(mc *minio.Client, v1 *viper.Viper, db *bolt.DB) {
 	st := time.Now()
 	log.Printf("Summoner start time: %s \n", st) // Log the time at start for the record
 
-	// Get a list of resource URLs that do and don't required headless processing
-	ru := acquire.ResourceURLs(v1, mc, false, db)
-	hru := acquire.ResourceURLs(v1, mc, true, db)
+	// Get a list of resource URLs that do and don't require headless processing
+	ru, err := acquire.ResourceURLs(v1, mc, false, db)
 
-	// TODO  These can be go funcs that run all at the same time..
-	if len(ru) > 0 {
-		acquire.ResRetrieve(v1, mc, ru, db)
+	if err != nil {
+		log.Printf("Error getting urls that do not require headless processing: %s", err)
+	} else if len(ru) > 0 {
+		//acquire.ResRetrieve(v1, mc, ru, db) // TODO  These can be go funcs that run all at the same time..
 	}
+	hru, err := acquire.ResourceURLs(v1, mc, true, db)
 
-	if len(hru) > 0 {
-		acquire.HeadlessNG(v1, mc, hru, db)
+	if err != nil {
+		log.Printf("Error getting urls that require headless processing: %s", err)
+	} else if len(hru) > 0 {
+		//acquire.HeadlessNG(v1, mc, hru, db)
 	}
 
 	// Time report

--- a/tools/boltminio/main.go
+++ b/tools/boltminio/main.go
@@ -74,7 +74,7 @@ func main() {
 	}
 
 	defer db.Close()
-	ru := acquire.ResourceURLs(v1, mc, false, db)
+	ru, err := acquire.ResourceURLs(v1, mc, false, db)
 	// hru := acquire.ResourceURLs(v1, true)
 	// log.Println(len(ru["samplesearth"].URL))
 	// log.Println(len(hru["samplesearth"].URL))

--- a/tools/siteprovdiff/main.go
+++ b/tools/siteprovdiff/main.go
@@ -73,7 +73,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer db.Close()
-	ru := acquire.ResourceURLs(v1, mc, false, db)
+	ru, err := acquire.ResourceURLs(v1, mc, false, db)
 	// hru := acquire.ResourceURLs(v1, true)
 	// log.Println(len(ru["samplesearth"].URL))
 	// log.Println(len(hru["samplesearth"].URL))


### PR DESCRIPTION
For https://github.com/gleanerio/gleaner/issues/27

Main features:
- Adds support for using a robots.txt file as a source url in the config, and a new `sourcetype`, called `robots`. This will get a sitemap, or list of sitemaps, from the robots.txt file that is given in the source config url, like so:
```
- name: npdc
  sourcetype: robots
  headless: false
  url: https://npdc.nl/robots.txt
  properName: Netherlands Polar Data Center
  domain: https://npdc.nl
  active: true
```
- Looks for a robots.txt file on a domain _even if one was not given in the _config_. If it finds one, it modifies crawl behavior to respect the crawl delay and allowed / disallowed paths in the robots.txt file

Other stuff that ended up in here:
- Adds a utility function to fetch and parse a robots.txt, given its url
- Adds some helper functions to the sources config class
- Removes a mystery `sleep`
- Addresses a todo: makes `resources.ResourceUrl` return an `err`