### PR TITLE
Add a headlesswait parameter

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,26 @@
+
+# Developer notes
+
+# glcon
+glcon integrates gleaner and nabu to make a single env
+
+## integrating with local nabu
+[see article](https://levelup.gitconnected.com/import-and-use-local-packages-in-your-go-application-885c35e5624)
+
+`require (
+....
+github.com/gleanerio/nabu v0.0.0-20211214151422-eda9e525f196
+...
+}
+
+replace (
+github.com/gleanerio/nabu v0.0.0-20211214151422-eda9e525f196 => ../nabu
+)`
+
+REMOVE WHEN COMMITTING FOR A PULL REQUEST
+
+
+## update nabu dependency
+if nabu code has been updated, the you need to update the dependency
+`go get -u github.com/gleanerio/nabu`
+

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,0 +1,30 @@
+
+# Developer notes
+
+## Repositories
+### Githubactions
+
+
+# glcon
+glcon integrates gleaner and nabu to make a single env
+
+## integrating with local nabu
+[see article](https://levelup.gitconnected.com/import-and-use-local-packages-in-your-go-application-885c35e5624)
+
+`require (
+....
+github.com/gleanerio/nabu v0.0.0-20211214151422-eda9e525f196
+...
+}
+
+replace (
+github.com/gleanerio/nabu v0.0.0-20211214151422-eda9e525f196 => ../nabu
+)`
+
+REMOVE WHEN COMMITTING FOR A PULL REQUEST
+
+
+## update nabu dependency
+if nabu code has been updated, the you need to update the dependency
+`go get -u github.com/gleanerio/nabu`
+

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 
 require (
 	github.com/boltdb/bolt v1.3.1
-	github.com/gleanerio/nabu v0.0.0-20211107193830-958398c3aaef
+	github.com/gleanerio/nabu v0.0.0-20211214151422-eda9e525f196
 	github.com/oxffaa/gopher-parse-sitemap v0.0.0-20191021113419-005d2eb1def4
 	github.com/samclarke/robotstxt v0.0.0-20171127213916-2817654b7988
 	github.com/tidwall/gjson v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gleanerio/gleaner v0.0.0-20211103190335-f9d8811ee43b/go.mod h1:Xx/8sK0tqQRLSYLsyTR9NeLTGKpwmUOIFat0ilWqguw=
 github.com/gleanerio/nabu v0.0.0-20211107193830-958398c3aaef h1:fJ3fh3AFktjmXd+FIv1lYyds80/n3Ao2DMNQfD8azJQ=
 github.com/gleanerio/nabu v0.0.0-20211107193830-958398c3aaef/go.mod h1:tGRxO9CPE3nh9CFvnejJVhoF9GRBqgfOfQbOT+VODJA=
+github.com/gleanerio/nabu v0.0.0-20211214151422-eda9e525f196 h1:FKElPrSdat0cCsax9JRzcRH6iRYQKT9cubLPxBAulYA=
+github.com/gleanerio/nabu v0.0.0-20211214151422-eda9e525f196/go.mod h1:8R1VJxKnob6bLfnTs45X2eFWsUfyarzg/o9D6wqM/WQ=
 github.com/glycerine/go-unsnap-stream v0.0.0-20181221182339-f9677308dec2/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=
 github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31/go.mod h1:Ogl1Tioa0aV7gstGFO7KhffUsb9M4ydbEbbxpcEDc24=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -349,6 +351,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
+github.com/kisielk/godepgraph v0.0.0-20190626013829-57a7e4a651a9/go.mod h1:Gb5YEgxqiSSVrXKWQxDcKoCM94NO5QAwOwTaVmIUAMI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.10.5/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=

--- a/internal/config/sources.go
+++ b/internal/config/sources.go
@@ -29,6 +29,7 @@ type Sources struct {
 	Other           map[string]interface{} `mapstructure:",remain"`
 	// SitemapFormat string
 	// Active        bool
+	HeadlessWait int // is loading is slow, wait
 }
 
 // add needed for file
@@ -42,6 +43,7 @@ type SourcesConfig struct {
 	Domain     string
 	// SitemapFormat string
 	// Active        bool
+	HeadlessWait int // is loading is slow, wait
 }
 
 var SourcesTemplate = map[string]interface{}{
@@ -55,6 +57,7 @@ var SourcesTemplate = map[string]interface{}{
 		"propername":      "",
 		"domain":          "",
 		"credentialsfile": "",
+		"headlesswait":    "0",
 	},
 }
 
@@ -172,7 +175,6 @@ func GetActiveSourceByHeadless(sources []Sources, headless bool) []Sources {
 	}
 	return sourcesSlice
 }
-
 
 func GetSourceByName(sources []Sources, name string) (Sources, error) {
 	for _, s := range sources {

--- a/internal/config/summoner.go
+++ b/internal/config/summoner.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 type Summoner struct {
@@ -37,6 +38,9 @@ func ReadSummmonerConfig(viperSubtree *viper.Viper) (Summoner, error) {
 	err := viperSubtree.Unmarshal(&summoner)
 	if err != nil {
 		panic(fmt.Errorf("error when parsing sparql endpoint config: %v", err))
+	}
+	if strings.HasSuffix(summoner.Headless, "/") {
+		panic(fmt.Errorf("headless warning should not end with / %v", summoner.Headless))
 	}
 	return summoner, err
 }

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -36,6 +36,7 @@ func ResRetrieve(v1 *viper.Viper, mc *minio.Client, m map[string][]string, db *b
 		go getDomain(v1, mc, urls, domain, &wg, db)
 	}
 
+	time.Sleep(2 * time.Second) // ?? why is this here?
 	wg.Wait()
 }
 


### PR DESCRIPTION
Headless rendering of one site requires a >1 second way to get an injected jsonld script.

fails in google schema tester.
See it in the local chrome.

This hack lets' the website render and we see the two jsonld blocks.

branch lands after dev_mm_robots... since that has a call to GetSourceByName which is needed to get the headless parameter from a source 