### PR TITLE
Fix up context urls to conform to the schema.org namespace spec

### DIFF
--- a/docs/README_Configure_Template.md
+++ b/docs/README_Configure_Template.md
@@ -179,10 +179,13 @@ sources:
 
 A few things we need to look at.
 
-First, in the "mino:" section make sure the accessKey and secretKey here are the ones you utlize.
+First, in the "minio:" section make sure the accessKey and secretKey here are the ones you utlize.
 Note: blank these out, and used environment variables (TODO:Need to describe them)
 
 Next, lets look at the "gleaner:" section.  We can set the runid to something.  This is the ID for a run and it allows you to later make different runs and keep the resulting graphs organized.  It can be set to any lower case string with no spaces. 
+
+The "context:" section is about the JSON-LD context, which is a top-level object in each JSON-LD metadata document. Most of the time, it'll look like the example context [here](https://github.com/ESIPFed/science-on-schema.org/blob/cbe618d1896ae8408b3d3575e7be6847129808ab/guides/Dataset.md#common-properties).
+By default, Gleaner will look for common mistakes in the JSON-LD context specification and fix them up. Setting `strict: true` here will disable those fixup operations. It might make things run a little faster to do this.
 
 The miller and summon sections are true and we will leave them that way.  It means we want Gleaner to both fetch the resources and process (mill) them.  
 

--- a/internal/summoner/acquire/jsonutils_test.go
+++ b/internal/summoner/acquire/jsonutils_test.go
@@ -80,3 +80,55 @@ func TestContextStringFix(t *testing.T) {
         assert.Nil(t, err)
     })
 }
+
+func TestContextUrlFix(t *testing.T) {
+    var httpContext = `{
+        "@context": {
+            "@vocab":"http://schema.org/"
+        },
+        "@type":"bar",
+        "SO:name":"Some type in a graph"
+    }`
+
+    var httpNoSlashContext = `{
+        "@context": {
+            "@vocab":"http://schema.org"
+        },
+        "@type":"bar",
+        "SO:name":"Some type in a graph"
+    }`
+
+    var noSlashContext = `{
+        "@context": {
+            "@vocab":"https://schema.org"
+        },
+        "@type":"bar",
+        "SO:name":"Some type in a graph"
+    }`
+
+    var expectedContext = `{
+        "@context": {
+            "@vocab":"https://schema.org/"
+        },
+        "@type":"bar",
+        "SO:name":"Some type in a graph"
+    }`
+
+    t.Run("It rewrites the jsonld context if it does not have a trailing slash", func(t *testing.T) {
+        result, err := fixContextUrl(noSlashContext)
+        assert.JSONEq(t, expectedContext, result)
+        assert.Nil(t, err)
+    })
+
+    t.Run("It rewrites the jsonld context if its schema is not https", func(t *testing.T) {
+        result, err := fixContextUrl(httpContext)
+        assert.JSONEq(t, expectedContext, result)
+        assert.Nil(t, err)
+    })
+
+    t.Run("It rewrites the jsonld context if it does not have a trailing slash or its schema is not https", func(t *testing.T) {
+        result, err := fixContextUrl(httpNoSlashContext)
+        assert.JSONEq(t, expectedContext, result)
+        assert.Nil(t, err)
+    })
+}


### PR DESCRIPTION
A full discussion of this issue is here: https://github.com/ESIPFed/science-on-schema.org/blob/cbe618d1896ae8408b3d3575e7be6847129808ab/decisions/52-namespace-consistency.md

But basically, what happens is that a context statement needs to have `https://schema.org/` in the `@vocab` property. A lot of people have `http://schema.org/` in their metadata or are missing the trailing slash there, or both. These are such tiny differences!

This change automatically adds a trailing slash where one is missing and sets the url scheme to be https. It also provides an config option, `context: strict: true` to *not* do those things.

I'm still testing these changes, so I'll take this PR out of draft status when I'm certain that it's ready. But i figured it'd be nice to get it in front of people.
