### PR TITLE
Robots.txt bug fixes and --rude flag

### DIFF
--- a/cmd/gleaner/main.go
+++ b/cmd/gleaner/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var viperVal, sourceVal, modeVal string
-var setupVal bool
+var setupVal, rudeVal bool
 
 func init() {
 	// Output to stdout instead of the default stderr. Can be any io.Writer, see below for File example
@@ -47,6 +47,7 @@ func init() {
 
 	flag.BoolVar(&setupVal, "setup", false, "Run Gleaner configuration check and exit")
 	flag.StringVar(&sourceVal, "source", "", "Override config file source(s) to specify an index target")
+	flag.BoolVar(&rudeVal, "rude", false, "Ignore any robots.txt crawl delays or allow / disallow statements")
 	flag.StringVar(&viperVal, "cfg", "config", "Configuration file (can be YAML, JSON) Do NOT provide the extension in the command line. -cfg file not -cfg file.yml")
 	flag.StringVar(&modeVal, "mode", "full", "Set the mode (full | diff) to index all or just diffs")
 }
@@ -122,6 +123,12 @@ func main() {
 		configMap := v1.AllSettings()
 		delete(configMap, "sources")
 		v1.Set("sources", tmp)
+
+		if rudeVal {
+			v1.Set("rude", true)
+		}
+	} else if rudeVal {
+		log.Println("--rude can only be used with --source, not globally.")
 	}
 
 	// Parse a new mode entry from command line if present

--- a/internal/config/sources.go
+++ b/internal/config/sources.go
@@ -178,7 +178,7 @@ func GetActiveSourceByHeadless(sources []Sources, headless bool) []Sources {
 }
 
 func GetSourceByName(sources []Sources, name string) (*Sources, error) {
-	for i := 0; i < len(sources); i++  {
+	for i := 0; i < len(sources); i++ {
 		if sources[i].Name == name {
 			return &sources[i], nil
 		}

--- a/internal/config/sources.go
+++ b/internal/config/sources.go
@@ -29,7 +29,7 @@ type Sources struct {
 	Other           map[string]interface{} `mapstructure:",remain"`
 	// SitemapFormat string
 	// Active        bool
-	HeadlessWait int   // is loading is slow, wait
+	HeadlessWait int   // if loading is slow, wait
 	Delay        int64 // A domain-specific crawl delay value
 }
 
@@ -177,13 +177,13 @@ func GetActiveSourceByHeadless(sources []Sources, headless bool) []Sources {
 	return sourcesSlice
 }
 
-func GetSourceByName(sources []Sources, name string) (Sources, error) {
-	for _, s := range sources {
-		if s.Name == name {
-			return s, nil
+func GetSourceByName(sources []Sources, name string) (*Sources, error) {
+	for i := 0; i < len(sources); i++  {
+		if sources[i].Name == name {
+			return &sources[i], nil
 		}
 	}
-	return Sources{}, fmt.Errorf("Unable to find a source with name %s", name)
+	return nil, fmt.Errorf("Unable to find a source with name %s", name)
 }
 
 func SourceToNabuPrefix(sources []Sources, includeProv bool) []string {

--- a/internal/config/sources.go
+++ b/internal/config/sources.go
@@ -29,7 +29,8 @@ type Sources struct {
 	Other           map[string]interface{} `mapstructure:",remain"`
 	// SitemapFormat string
 	// Active        bool
-	HeadlessWait int // is loading is slow, wait
+	HeadlessWait int   // is loading is slow, wait
+	Delay        int64 // A domain-specific crawl delay value
 }
 
 // add needed for file

--- a/internal/config/sources_test.go
+++ b/internal/config/sources_test.go
@@ -162,7 +162,7 @@ func TestGetSourceByName(t *testing.T) {
 		}
 
 		results, err := GetSourceByName(sources, "test1")
-		assert.EqualValues(t, expected, results)
+		assert.EqualValues(t, &expected, results)
 		assert.Nil(t, err)
 
 	})

--- a/internal/config/sources_test.go
+++ b/internal/config/sources_test.go
@@ -1,34 +1,33 @@
 package config
 
-import
-(
-    "testing"
-    "github.com/stretchr/testify/assert"
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 var sources = []Sources{
 	{
-		Name: "test1",
-		Headless: true,
-		Active: true,
+		Name:       "test1",
+		Headless:   true,
+		Active:     true,
 		SourceType: "sitemap",
 	},
 	{
-		Name: "test2",
-		Headless: false,
-		Active: true,
+		Name:       "test2",
+		Headless:   false,
+		Active:     true,
 		SourceType: "robots",
 	},
 	{
-		Name: "test3",
-		Headless: false,
-		Active: false,
+		Name:       "test3",
+		Headless:   false,
+		Active:     false,
 		SourceType: "sitemap",
 	},
 	{
-		Name: "test4",
-		Headless: true,
-		Active: false,
+		Name:       "test4",
+		Headless:   true,
+		Active:     false,
 		SourceType: "sitemap",
 	},
 }
@@ -37,26 +36,26 @@ var empty = []Sources{}
 
 func TestGetSourceByType(t *testing.T) {
 	t.Run("It gets sources of the given type", func(t *testing.T) {
-	expected := []Sources{
-		{
-			Name: "test1",
-			Headless: true,
-			Active: true,
-			SourceType: "sitemap",
-		},
-		{
-			Name: "test3",
-			Headless: false,
-			Active: false,
-			SourceType: "sitemap",
-		},
-		{
-			Name: "test4",
-			Headless: true,
-			Active: false,
-			SourceType: "sitemap",
-		},
-	}
+		expected := []Sources{
+			{
+				Name:       "test1",
+				Headless:   true,
+				Active:     true,
+				SourceType: "sitemap",
+			},
+			{
+				Name:       "test3",
+				Headless:   false,
+				Active:     false,
+				SourceType: "sitemap",
+			},
+			{
+				Name:       "test4",
+				Headless:   true,
+				Active:     false,
+				SourceType: "sitemap",
+			},
+		}
 		results := GetSourceByType(sources, "sitemap")
 		assert.ElementsMatch(t, expected, results)
 	})
@@ -66,7 +65,7 @@ func TestGetSourceByType(t *testing.T) {
 		assert.ElementsMatch(t, empty, results)
 	})
 
-	t.Run("It handles an empty source slice correctly", func(t *testing.T){
+	t.Run("It handles an empty source slice correctly", func(t *testing.T) {
 		results := GetSourceByType(empty, "sitemap")
 		assert.ElementsMatch(t, empty, results)
 	})
@@ -76,9 +75,9 @@ func TestGetActiveSourceByType(t *testing.T) {
 	t.Run("It gets active sources of the given type", func(t *testing.T) {
 		expected := []Sources{
 			{
-				Name: "test1",
-				Headless: true,
-				Active: true,
+				Name:       "test1",
+				Headless:   true,
+				Active:     true,
 				SourceType: "sitemap",
 			},
 		}
@@ -91,7 +90,7 @@ func TestGetActiveSourceByType(t *testing.T) {
 		assert.ElementsMatch(t, empty, results)
 	})
 
-	t.Run("It handles an empty source slice correctly", func(t *testing.T){
+	t.Run("It handles an empty source slice correctly", func(t *testing.T) {
 		results := GetActiveSourceByType(empty, "sitemap")
 		assert.ElementsMatch(t, empty, results)
 	})
@@ -101,9 +100,9 @@ func TestGetActiveSourceByHeadless(t *testing.T) {
 	t.Run("It gets active sources of the given type", func(t *testing.T) {
 		expectedTrue := []Sources{
 			{
-				Name: "test1",
-				Headless: true,
-				Active: true,
+				Name:       "test1",
+				Headless:   true,
+				Active:     true,
 				SourceType: "sitemap",
 			},
 		}
@@ -112,9 +111,9 @@ func TestGetActiveSourceByHeadless(t *testing.T) {
 
 		expectedFalse := []Sources{
 			{
-				Name: "test2",
-				Headless: false,
-				Active: true,
+				Name:       "test2",
+				Headless:   false,
+				Active:     true,
 				SourceType: "robots",
 			},
 		}
@@ -124,30 +123,30 @@ func TestGetActiveSourceByHeadless(t *testing.T) {
 
 	t.Run("It returns an empty slice if there are no such sources", func(t *testing.T) {
 		test := []Sources{
-		{
-			Name: "test1",
-			Headless: true,
-			Active: true,
-			SourceType: "sitemap",
-		},
-		{
-			Name: "test3",
-			Headless: false,
-			Active: false,
-			SourceType: "sitemap",
-		},
-		{
-			Name: "test4",
-			Headless: true,
-			Active: false,
-			SourceType: "sitemap",
-		},
-	}
+			{
+				Name:       "test1",
+				Headless:   true,
+				Active:     true,
+				SourceType: "sitemap",
+			},
+			{
+				Name:       "test3",
+				Headless:   false,
+				Active:     false,
+				SourceType: "sitemap",
+			},
+			{
+				Name:       "test4",
+				Headless:   true,
+				Active:     false,
+				SourceType: "sitemap",
+			},
+		}
 		results := GetActiveSourceByHeadless(test, false)
 		assert.ElementsMatch(t, empty, results)
 	})
 
-	t.Run("It handles an empty source slice correctly", func(t *testing.T){
+	t.Run("It handles an empty source slice correctly", func(t *testing.T) {
 		results := GetActiveSourceByHeadless(empty, true)
 		assert.ElementsMatch(t, empty, results)
 	})
@@ -156,9 +155,9 @@ func TestGetActiveSourceByHeadless(t *testing.T) {
 func TestGetSourceByName(t *testing.T) {
 	t.Run("It gets sources of the given name", func(t *testing.T) {
 		expected := Sources{
-			Name: "test1",
-			Headless: true,
-			Active: true,
+			Name:       "test1",
+			Headless:   true,
+			Active:     true,
 			SourceType: "sitemap",
 		}
 
@@ -174,7 +173,7 @@ func TestGetSourceByName(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 
-	t.Run("It handles an empty source slice correctly", func(t *testing.T){
+	t.Run("It handles an empty source slice correctly", func(t *testing.T) {
 		results, err := GetSourceByName(empty, "test1")
 		assert.ElementsMatch(t, empty, results)
 		assert.NotNil(t, err)

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -57,7 +57,7 @@ func getConfig(v1 *viper.Viper, sourceName string) (string, int, int64, error) {
 	domainDelay := v1.Get("sources." + sourceName + ".Delay")
 	if domainDelay != nil && domainDelay.(int64) != 0 {
 		delay = domainDelay.(int64)
-		log.Printf("Crawl delay set to %i for %s", delay, sourceName)
+		log.Printf("Crawl delay set to %d for %s", delay, sourceName)
 	}
 
 	if delay != 0 {

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -54,7 +54,7 @@ func getConfig(v1 *viper.Viper, sourceName string) (string, int, int64, error) {
 	delay := mcfg.Delay
 
 	// look for a domain specific override crawl delay
-	domainDelay := v1.Get("sources." + sourceName + ".Delay")
+	domainDelay := v1.Get("sources." + sourceName + ".delay")
 	if domainDelay != nil && domainDelay.(int64) != 0 {
 		delay = domainDelay.(int64)
 		log.Printf("Crawl delay set to %d for %s", delay, sourceName)

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/minio/minio-go/v7"
-	"github.com/samclarke/robotstxt"
 	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/viper"
 	bolt "go.etcd.io/bbolt"
@@ -38,7 +37,7 @@ func ResRetrieve(v1 *viper.Viper, mc *minio.Client, m map[string][]string, db *b
 	wg.Wait()
 }
 
-func getConfig(v1 *viper.Viper) (string, int, int64, error) {
+func getConfig(v1 *viper.Viper, sourceName string) (string, int, int64, error) {
 	bucketName, err := configTypes.GetBucketName(v1)
 	if err != nil {
 		return bucketName, 0, 0, err
@@ -46,8 +45,18 @@ func getConfig(v1 *viper.Viper) (string, int, int64, error) {
 
 	var mcfg configTypes.Summoner
 	mcfg, err = configTypes.ReadSummmonerConfig(v1.Sub("summoner"))
+
+	// Set default thread counts and global delay
 	tc := mcfg.Threads
 	delay := mcfg.Delay
+
+	// look for a domain specific override crawl delay
+	sourcesConfig, err := configTypes.GetSources(v1)
+	domain, err := configTypes.GetSourceByName(sourcesConfig, sourceName)
+
+	if domain.Delay != 0 {
+		delay = domain.Delay
+	}
 
 	if err != nil {
 		return bucketName, tc, delay, err
@@ -61,31 +70,6 @@ func getConfig(v1 *viper.Viper) (string, int, int64, error) {
 	return bucketName, tc, delay, nil
 }
 
-func getRobotsForDomain(v1 *viper.Viper, sourceName string) (*robotstxt.RobotsTxt, error) {
-	// first get the domain url for our source
-	sourcesConfig, err := configTypes.GetSources(v1)
-	domain, err := configTypes.GetSourceByName(sourcesConfig, sourceName)
-	if err != nil {
-		log.Printf("error getting domain url for %s : %s  ", sourceName, err)
-		return nil, err
-	}
-
-	var robotsUrl string
-	if domain.SourceType == "robots" {
-		robotsUrl = domain.URL
-	} else {
-		robotsUrl = domain.Domain + "/robots.txt"
-	}
-
-	robots, err := getRobotsTxt(robotsUrl)
-	if err != nil {
-		log.Printf("error getting robots.txt for %s : %s  ", sourceName, err)
-		return nil, err
-	}
-
-	return robots, nil
-}
-
 func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName string, wg *sync.WaitGroup, db *bolt.DB) {
 
 	// make the bucket (if it doesn't exist)
@@ -97,32 +81,12 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 		return nil
 	})
 
-	bucketName, tc, delay, err := getConfig(v1)
+	bucketName, tc, delay, err := getConfig(v1, sourceName)
 	if err != nil {
 		log.Panic("Error reading config file", err)
 	}
 
 	var client http.Client
-
-	robots, err := getRobotsForDomain(v1, sourceName)
-
-	if err != nil {
-		log.Printf("Error getting robots.txt for %s; continuing without it.", sourceName)
-	}
-
-	// Look at the crawl delay from this domain's robots.txt, if we can, and one exists.
-	if robots != nil {
-		// this is a time.Duration, which is in nanoseconds, because of COURSE it is, but we want milliseconds
-		crawlDelay := int64(robots.CrawlDelay(EarthCubeAgent) / time.Millisecond)
-		log.Printf("Crawl Delay specified by robots.txt for %s: %d", sourceName, crawlDelay)
-
-		// If our default delay is less than what is set there, bump up the delay for this
-		// domain to respect the robots.txt setting.
-		if delay < crawlDelay {
-			delay = crawlDelay
-			tc = 1 // any delay means going down to one thread.
-		}
-	}
 
 	semaphoreChan := make(chan struct{}, tc) // a blocking channel to keep concurrency under control
 	defer close(semaphoreChan)
@@ -147,19 +111,6 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 		go func(i int, sourceName string) {
 			semaphoreChan <- struct{}{}
 			log.Println("Indexing", urlloc)
-
-			urlloc = strings.ReplaceAll(urlloc, " ", "")
-			urlloc = strings.ReplaceAll(urlloc, "\n", "")
-
-			if robots != nil {
-				allowed, err := robots.IsAllowed(EarthCubeAgent, urlloc)
-				if !allowed {
-					log.Printf("Declining to index %s because it is disallowed by robots.txt. Error information, if any: %s", urlloc, err)
-					lwg.Done() // tell the wait group that we be done
-					<-semaphoreChan
-					return
-				}
-			}
 
 			req, err := http.NewRequest("GET", urlloc, nil)
 			if err != nil {

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -53,15 +53,22 @@ func getConfig(v1 *viper.Viper, sourceName string) (string, int, int64, error) {
 	tc := mcfg.Threads
 	delay := mcfg.Delay
 
-	// look for a domain specific override crawl delay
-	domainDelay := v1.Get("sources." + sourceName + ".delay")
-	if domainDelay != nil && domainDelay.(int64) != 0 {
-		delay = domainDelay.(int64)
-		log.Printf("Crawl delay set to %d for %s", delay, sourceName)
-	}
-
 	if delay != 0 {
 		tc = 1
+	}
+
+	// look for a domain specific override crawl delay
+	sources, err := configTypes.GetSources(v1)
+	source, err := configTypes.GetSourceByName(sources, sourceName)
+
+	if err != nil {
+		return bucketName, tc, delay, err
+	}
+
+	if source.Delay != 0 && source.Delay > delay {
+		delay = source.Delay
+		tc = 1
+		log.Printf("Crawl delay set to %d for %s", delay, sourceName)
 	}
 
 	log.Printf("Thread count %d delay %d\n", tc, delay)

--- a/internal/summoner/acquire/acquire_test.go
+++ b/internal/summoner/acquire/acquire_test.go
@@ -68,15 +68,13 @@ func TestGetConfig(t *testing.T) {
 		conf := map[string]interface{}{
 			"minio": map[string]interface{}{"bucket": "test"},
 			"summoner": map[string]interface{}{"threads": "5", "delay": 5},
-			"sources": []map[string]string{{"name": "testSource", "delay": "100"}},
+			"sources": []map[string]interface{}{{"name": "testSource", "delay": 100}},
 		}
 
 		var viper = viper.New()
 		for key, value := range conf {
 			viper.Set(key, value)
 		}
-		viper.Set("sources.testSource.delay", int64(100))
-		assert.Equal(t, int64(100), viper.Get("sources.testSource.delay"))
 
 		bucketName, tc, delay, err := getConfig(viper, "testSource")
 		assert.Equal(t, "test", bucketName)
@@ -86,7 +84,7 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("It does not override a global summoner delay if the data source does not have a longer one specified", func(t *testing.T) {
-		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": 50}, "sources": map[string]interface{}{"name": "testSource", "delay": 10}}
+		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": 50}, "sources": []map[string]interface{}{{"name": "testSource", "delay": 10}}}
 
 		var viper = viper.New()
 		for key, value := range conf {

--- a/internal/summoner/acquire/acquire_test.go
+++ b/internal/summoner/acquire/acquire_test.go
@@ -10,15 +10,15 @@ import (
 )
 
 func TestGetConfig(t *testing.T) {
-	t.Run("It reads a config and returns the expected information", func(t *testing.T) {
-		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": "0"}}
+	t.Run("It reads a config for an indexing source and returns the expected information", func(t *testing.T) {
+		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": "0"}, "sources": map[string]interface{}{"name": "testSource"}}
 
 		var viper = viper.New()
 		for key, value := range conf {
 			viper.Set(key, value)
 		}
 
-		bucketName, tc, delay, err := getConfig(viper)
+		bucketName, tc, delay, err := getConfig(viper, "testSource")
 		assert.Equal(t, "test", bucketName)
 		assert.Equal(t, 5, tc)
 		assert.Equal(t, int64(0), delay)
@@ -26,14 +26,14 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("It sets the thread count to 1 if a delay is specified", func(t *testing.T) {
-		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": "1000"}}
+		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": "1000"}, "sources": map[string]interface{}{"name": "testSource"}}
 
 		var viper = viper.New()
 		for key, value := range conf {
 			viper.Set(key, value)
 		}
 
-		bucketName, tc, delay, err := getConfig(viper)
+		bucketName, tc, delay, err := getConfig(viper, "testSource")
 		assert.Equal(t, "test", bucketName)
 		assert.Equal(t, 1, tc)
 		assert.Equal(t, int64(1000), delay)
@@ -41,73 +41,47 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("It allows delay to be optional", func(t *testing.T) {
-		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5"}}
+		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5"}, "sources": map[string]interface{}{"name": "testSource"}}
 
 		var viper = viper.New()
 		for key, value := range conf {
 			viper.Set(key, value)
 		}
 
-		bucketName, tc, delay, err := getConfig(viper)
+		bucketName, tc, delay, err := getConfig(viper, "testSource")
 		assert.Equal(t, "test", bucketName)
 		assert.Equal(t, 5, tc)
 		assert.Equal(t, int64(0), delay)
 		assert.Nil(t, err)
 	})
-}
 
-func TestGetRobotsForDomain(t *testing.T) {
-	var robots = `User-agent: *
-		Disallow: /cgi-bin
-		Disallow: /forms
-		Disallow: /api/gi-cat
-		Disallow: /rocs/archives-catalog
-		Crawl-delay: 10`
+	t.Run("It overrides a global summoner delay if the data source has a longer one specified", func(t *testing.T) {
+		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": "5"}, "sources": map[string]interface{}{"name": "testSource", "delay": "100"}}
 
-	var robots2 = `User-agent: *
-		Crawl-delay: 5`
+		var viper = viper.New()
+		for key, value := range conf {
+			viper.Set(key, value)
+		}
 
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, req *http.Request) {
-		w.Write([]byte(robots))
-	})
-	mux.HandleFunc("/test-robots.txt", func(w http.ResponseWriter, req *http.Request) {
-		w.Write([]byte(robots2))
-	})
-	// generate a test server so we can capture and inspect the request
-	testServer := httptest.NewServer(mux)
-	defer func() { testServer.Close() }()
-
-	conf := map[string]interface{}{
-		"sources": []map[string]string{
-			{"name": "test", "domain": testServer.URL},
-			{"name": "test-robots", "domain": testServer.URL, "url": testServer.URL + "/test-robots.txt", "sourcetype": "robots"},
-		},
-	}
-
-	var viper = viper.New()
-	for key, value := range conf {
-		viper.Set(key, value)
-	}
-
-	t.Run("It returns an object representing robots.txt when specified", func(t *testing.T) {
-		robots, err := getRobotsForDomain(viper, "test")
-		assert.NotNil(t, robots)
+		bucketName, tc, delay, err := getConfig(viper, "testSource")
+		assert.Equal(t, "test", bucketName)
+		assert.Equal(t, 1, tc)
+		assert.Equal(t, int64(100), delay)
 		assert.Nil(t, err)
-		assert.Equal(t, time.Duration(10000000000), robots.CrawlDelay("*"))
 	})
 
-	t.Run("It returns nil if there is an error", func(t *testing.T) {
-		robots, err := getRobotsForDomain(viper, "bad-value")
-		assert.Nil(t, robots)
-		assert.NotNil(t, err)
-	})
+	t.Run("It does not override a global summoner delay if the data source does not have a longer one specified", func(t *testing.T) {
+		conf := map[string]interface{}{"minio": map[string]interface{}{"bucket": "test"}, "summoner": map[string]interface{}{"threads": "5", "delay": "50"}, "sources": map[string]interface{}{"name": "testSource", "delay": "10"}}
 
-	t.Run("It uses the specified robots url instead of building one if the sources type is robots", func(t *testing.T) {
-		robots, err := getRobotsForDomain(viper, "test-robots")
-		assert.NotNil(t, robots)
+		var viper = viper.New()
+		for key, value := range conf {
+			viper.Set(key, value)
+		}
+
+		bucketName, tc, delay, err := getConfig(viper, "testSource")
+		assert.Equal(t, "test", bucketName)
+		assert.Equal(t, 1, tc)
+		assert.Equal(t, int64(50), delay)
 		assert.Nil(t, err)
-		assert.Equal(t, time.Duration(5000000000), robots.CrawlDelay("*"))
 	})
 }

--- a/internal/summoner/acquire/acquire_test.go
+++ b/internal/summoner/acquire/acquire_test.go
@@ -1,13 +1,12 @@
 package acquire
 
-import
-(
+import (
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 	"time"
-    "testing"
-    "github.com/stretchr/testify/assert"
-    "github.com/spf13/viper"
 )
 
 func TestGetConfig(t *testing.T) {
@@ -71,11 +70,11 @@ func TestGetRobotsForDomain(t *testing.T) {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, req *http.Request) {
-	    w.Write([]byte(robots))
-    })
-    mux.HandleFunc("/test-robots.txt", func(w http.ResponseWriter, req *http.Request) {
-	    w.Write([]byte(robots2))
-    })
+		w.Write([]byte(robots))
+	})
+	mux.HandleFunc("/test-robots.txt", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(robots2))
+	})
 	// generate a test server so we can capture and inspect the request
 	testServer := httptest.NewServer(mux)
 	defer func() { testServer.Close() }()
@@ -83,7 +82,7 @@ func TestGetRobotsForDomain(t *testing.T) {
 	conf := map[string]interface{}{
 		"sources": []map[string]string{
 			{"name": "test", "domain": testServer.URL},
-			{"name": "test-robots", "domain": testServer.URL, "url": testServer.URL + "/test-robots.txt", "sourcetype": "robots" },
+			{"name": "test-robots", "domain": testServer.URL, "url": testServer.URL + "/test-robots.txt", "sourcetype": "robots"},
 		},
 	}
 
@@ -106,7 +105,7 @@ func TestGetRobotsForDomain(t *testing.T) {
 	})
 
 	t.Run("It uses the specified robots url instead of building one if the sources type is robots", func(t *testing.T) {
-	    robots, err := getRobotsForDomain(viper, "test-robots")
+		robots, err := getRobotsForDomain(viper, "test-robots")
 		assert.NotNil(t, robots)
 		assert.Nil(t, err)
 		assert.Equal(t, time.Duration(5000000000), robots.CrawlDelay("*"))

--- a/internal/summoner/acquire/acquire_test.go
+++ b/internal/summoner/acquire/acquire_test.go
@@ -9,9 +9,9 @@ import (
 func TestGetConfig(t *testing.T) {
 	t.Run("It reads a config for an indexing source and returns the expected information", func(t *testing.T) {
 		conf := map[string]interface{}{
-			"minio": map[string]interface{}{"bucket": "test"},
+			"minio":    map[string]interface{}{"bucket": "test"},
 			"summoner": map[string]interface{}{"threads": "5", "delay": 0},
-			"sources": []map[string]interface{}{{"name": "testSource"}},
+			"sources":  []map[string]interface{}{{"name": "testSource"}},
 		}
 
 		var viper = viper.New()
@@ -28,9 +28,9 @@ func TestGetConfig(t *testing.T) {
 
 	t.Run("It sets the thread count to 1 if a delay is specified", func(t *testing.T) {
 		conf := map[string]interface{}{
-			"minio": map[string]interface{}{"bucket": "test"},
+			"minio":    map[string]interface{}{"bucket": "test"},
 			"summoner": map[string]interface{}{"threads": "5", "delay": 1000},
-			"sources": []map[string]interface{}{{"name": "testSource"}},
+			"sources":  []map[string]interface{}{{"name": "testSource"}},
 		}
 
 		var viper = viper.New()
@@ -47,9 +47,9 @@ func TestGetConfig(t *testing.T) {
 
 	t.Run("It allows delay to be optional", func(t *testing.T) {
 		conf := map[string]interface{}{
-			"minio": map[string]interface{}{"bucket": "test"},
+			"minio":    map[string]interface{}{"bucket": "test"},
 			"summoner": map[string]interface{}{"threads": "5"},
-			"sources": []map[string]interface{}{{"name": "testSource"}},
+			"sources":  []map[string]interface{}{{"name": "testSource"}},
 		}
 
 		var viper = viper.New()
@@ -66,9 +66,9 @@ func TestGetConfig(t *testing.T) {
 
 	t.Run("It overrides a global summoner delay if the data source has a longer one specified", func(t *testing.T) {
 		conf := map[string]interface{}{
-			"minio": map[string]interface{}{"bucket": "test"},
+			"minio":    map[string]interface{}{"bucket": "test"},
 			"summoner": map[string]interface{}{"threads": "5", "delay": 5},
-			"sources": []map[string]interface{}{{"name": "testSource", "delay": 100}},
+			"sources":  []map[string]interface{}{{"name": "testSource", "delay": 100}},
 		}
 
 		var viper = viper.New()

--- a/internal/summoner/acquire/jsonutils.go
+++ b/internal/summoner/acquire/jsonutils.go
@@ -80,7 +80,6 @@ func fixContextUrl(jsonld string) (string, error) {
 	return jsonld, err
 }
 
-
 func Upload(v1 *viper.Viper, mc *minio.Client, bucketName string, site string, urlloc string, jsonld string) (string, error) {
 	mcfg := v1.GetStringMapString("context")
 	var err error

--- a/internal/summoner/acquire/jsonutils.go
+++ b/internal/summoner/acquire/jsonutils.go
@@ -56,8 +56,8 @@ func fixContextString(jsonld string) (string, error) {
 	jsonContext := gjson.Get(jsonld, "@context")
 
 	switch jsonContext.Value().(type) {
-		case string:
-			jsonld, err = sjson.Set(jsonld, "@context", map[string]interface{}{"@vocab": jsonContext.String()})
+	case string:
+		jsonld, err = sjson.Set(jsonld, "@context", map[string]interface{}{"@vocab": jsonContext.String()})
 	}
 	return jsonld, err
 }
@@ -67,7 +67,7 @@ func fixContextString(jsonld string) (string, error) {
 func fixContextUrl(jsonld string) (string, error) {
 	var err error
 	context := gjson.Get(jsonld, "@context.@vocab").String()
-	if ! strings.HasSuffix(context, "/") {
+	if !strings.HasSuffix(context, "/") {
 		context += "/"
 	}
 	contextUrl, err := url.Parse(context)
@@ -80,7 +80,8 @@ func fixContextUrl(jsonld string) (string, error) {
 	return jsonld, err
 }
 
-func Upload(v1 *viper.Viper, mc *minio.Client, bucketName string, site string,  urlloc string, jsonld string) (string, error) {
+
+func Upload(v1 *viper.Viper, mc *minio.Client, bucketName string, site string, urlloc string, jsonld string) (string, error) {
 	mcfg := v1.GetStringMapString("context")
 	var err error
 	// In the config file, context { strict: true } bypasses these fixups.

--- a/internal/summoner/acquire/jsonutils_test.go
+++ b/internal/summoner/acquire/jsonutils_test.go
@@ -1,10 +1,9 @@
 package acquire
 
-import
-(
-	"testing"
+import (
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-    "github.com/spf13/viper"
+	"testing"
 )
 
 var invalidJson = `This isn't JSON at all.`
@@ -24,37 +23,37 @@ var validJson = `{
 var v1 = viper.New()
 
 func TestIsValid(t *testing.T) {
-    t.Run("It returns true for valid JSON-LD", func(t *testing.T) {
-        result, err := isValid(v1, validJson)
-        assert.Equal(t, true, result)
-        assert.Nil(t, err)
-    })
-    t.Run("It returns false and throws an error for invalid JSON-LD", func(t *testing.T) {
-        result, err := isValid(v1, invalidJson)
-        assert.Equal(t, false, result)
-        assert.NotNil(t, err)
-    })
+	t.Run("It returns true for valid JSON-LD", func(t *testing.T) {
+		result, err := isValid(v1, validJson)
+		assert.Equal(t, true, result)
+		assert.Nil(t, err)
+	})
+	t.Run("It returns false and throws an error for invalid JSON-LD", func(t *testing.T) {
+		result, err := isValid(v1, invalidJson)
+		assert.Equal(t, false, result)
+		assert.NotNil(t, err)
+	})
 
-    // to do: test for valid JSON but invalid RDF triples
+	// to do: test for valid JSON but invalid RDF triples
 }
 
 func TestAddToJsonListIfValid(t *testing.T) {
-    original := []string{"test"}
+	original := []string{"test"}
 
-    t.Run("It appends valid json to the array", func(t *testing.T) {
-        result, err := addToJsonListIfValid(v1, original, validJson)
-        assert.Equal(t, []string{"test", validJson}, result)
-        assert.Nil(t, err)
-    })
-    t.Run("It does not append invalid json to the array", func(t *testing.T) {
-        result, err := addToJsonListIfValid(v1, original, invalidJson)
-        assert.Equal(t, original, result)
-        assert.NotNil(t, err)
-    })
+	t.Run("It appends valid json to the array", func(t *testing.T) {
+		result, err := addToJsonListIfValid(v1, original, validJson)
+		assert.Equal(t, []string{"test", validJson}, result)
+		assert.Nil(t, err)
+	})
+	t.Run("It does not append invalid json to the array", func(t *testing.T) {
+		result, err := addToJsonListIfValid(v1, original, invalidJson)
+		assert.Equal(t, original, result)
+		assert.NotNil(t, err)
+	})
 }
 
 func TestContextStringFix(t *testing.T) {
-    var contextObjectJson = `{
+	var contextObjectJson = `{
         "@context": {
             "@vocab":"http://schema.org/"
         },
@@ -62,27 +61,27 @@ func TestContextStringFix(t *testing.T) {
         "SO:name":"Some type in a graph"
     }`
 
-    var contextStringJson = `{
+	var contextStringJson = `{
         "@context": "http://schema.org/",
         "@type":"bar",
         "SO:name":"Some type in a graph"
     }`
 
-    t.Run("It rewrites the jsonld context if it is not an object", func(t *testing.T) {
-        result, err := fixContextString(contextStringJson)
-        assert.JSONEq(t, contextObjectJson, result)
-        assert.Nil(t, err)
-    })
+	t.Run("It rewrites the jsonld context if it is not an object", func(t *testing.T) {
+		result, err := fixContextString(contextStringJson)
+		assert.JSONEq(t, contextObjectJson, result)
+		assert.Nil(t, err)
+	})
 
-    t.Run("It does not change the jsonld context if it is already an object", func(t *testing.T) {
-        result, err := fixContextString(contextObjectJson)
-        assert.Equal(t, contextObjectJson, result)
-        assert.Nil(t, err)
-    })
+	t.Run("It does not change the jsonld context if it is already an object", func(t *testing.T) {
+		result, err := fixContextString(contextObjectJson)
+		assert.Equal(t, contextObjectJson, result)
+		assert.Nil(t, err)
+	})
 }
 
 func TestContextUrlFix(t *testing.T) {
-    var httpContext = `{
+	var httpContext = `{
         "@context": {
             "@vocab":"http://schema.org/"
         },
@@ -90,7 +89,7 @@ func TestContextUrlFix(t *testing.T) {
         "SO:name":"Some type in a graph"
     }`
 
-    var httpNoSlashContext = `{
+	var httpNoSlashContext = `{
         "@context": {
             "@vocab":"http://schema.org"
         },
@@ -98,7 +97,7 @@ func TestContextUrlFix(t *testing.T) {
         "SO:name":"Some type in a graph"
     }`
 
-    var noSlashContext = `{
+	var noSlashContext = `{
         "@context": {
             "@vocab":"https://schema.org"
         },
@@ -106,7 +105,7 @@ func TestContextUrlFix(t *testing.T) {
         "SO:name":"Some type in a graph"
     }`
 
-    var expectedContext = `{
+	var expectedContext = `{
         "@context": {
             "@vocab":"https://schema.org/"
         },
@@ -114,21 +113,21 @@ func TestContextUrlFix(t *testing.T) {
         "SO:name":"Some type in a graph"
     }`
 
-    t.Run("It rewrites the jsonld context if it does not have a trailing slash", func(t *testing.T) {
-        result, err := fixContextUrl(noSlashContext)
-        assert.JSONEq(t, expectedContext, result)
-        assert.Nil(t, err)
-    })
+	t.Run("It rewrites the jsonld context if it does not have a trailing slash", func(t *testing.T) {
+		result, err := fixContextUrl(noSlashContext)
+		assert.JSONEq(t, expectedContext, result)
+		assert.Nil(t, err)
+	})
 
-    t.Run("It rewrites the jsonld context if its schema is not https", func(t *testing.T) {
-        result, err := fixContextUrl(httpContext)
-        assert.JSONEq(t, expectedContext, result)
-        assert.Nil(t, err)
-    })
+	t.Run("It rewrites the jsonld context if its schema is not https", func(t *testing.T) {
+		result, err := fixContextUrl(httpContext)
+		assert.JSONEq(t, expectedContext, result)
+		assert.Nil(t, err)
+	})
 
-    t.Run("It rewrites the jsonld context if it does not have a trailing slash or its schema is not https", func(t *testing.T) {
-        result, err := fixContextUrl(httpNoSlashContext)
-        assert.JSONEq(t, expectedContext, result)
-        assert.Nil(t, err)
-    })
+	t.Run("It rewrites the jsonld context if it does not have a trailing slash or its schema is not https", func(t *testing.T) {
+		result, err := fixContextUrl(httpNoSlashContext)
+		assert.JSONEq(t, expectedContext, result)
+		assert.Nil(t, err)
+	})
 }

--- a/internal/summoner/acquire/resources.go
+++ b/internal/summoner/acquire/resources.go
@@ -50,11 +50,17 @@ func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB)
 	sitemapDomains := configTypes.GetActiveSourceByType(domains, siteMapType)
 
 	for _, domain := range sitemapDomains {
-		robots, err := getRobotsForDomain(domain.Domain)
-
-		if err != nil {
-			log.Printf("Error getting robots.txt for %s; continuing without it.", domain.Name)
+		var robots *robotstxt.RobotsTxt
+		if v1.Get("rude") == true {
+			robots = nil
+			log.Printf("Rude indexing mode enabled; ignoring robots.txt.")
+		} else {
+			robots, err = getRobotsForDomain(domain.Domain)
+			if err != nil {
+				log.Printf("Error getting robots.txt for %s; continuing without it.", domain.Name)
+			}
 		}
+
 		urls, err := getSitemapURLList(domain.URL, robots)
 		if err != nil {
 			log.Println("Error getting sitemap urls for: ", domain.Name, err)

--- a/internal/summoner/acquire/resources.go
+++ b/internal/summoner/acquire/resources.go
@@ -167,13 +167,12 @@ func overrideCrawlDelayFromRobots(v1 *viper.Viper, sourceName string, delay int6
 
 func getRobotsForDomain(url string) (*robotstxt.RobotsTxt, error) {
 	robotsUrl := url + "/robots.txt"
-
+	log.Printf("Getting robots.txt from %s", robotsUrl)
 	robots, err := getRobotsTxt(robotsUrl)
 	if err != nil {
 		log.Printf("error getting robots.txt for %s : %s  ", url, err)
 		return nil, err
 	}
-
 	return robots, nil
 }
 

--- a/internal/summoner/acquire/resources.go
+++ b/internal/summoner/acquire/resources.go
@@ -160,7 +160,14 @@ func overrideCrawlDelayFromRobots(v1 *viper.Viper, sourceName string, delay int6
 		// If our default delay is less than what is set there, set a delay for this
 		// domain to respect the robots.txt setting.
 		if delay < crawlDelay {
-			v1.Set("sources."+sourceName+".delay", crawlDelay)
+			sources, err := configTypes.GetSources(v1)
+			source, err := configTypes.GetSourceByName(sources, sourceName)
+
+			if err != nil {
+				log.Printf("Error setting crawl delay override for %s : %s", sourceName, err)
+				return
+			}
+			source.Delay = crawlDelay
 		}
 	}
 }

--- a/internal/summoner/acquire/resources.go
+++ b/internal/summoner/acquire/resources.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"strings"
+	"time"
 
 	configTypes "github.com/gleanerio/gleaner/internal/config"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/samclarke/robotstxt"
 
 	"github.com/gleanerio/gleaner/internal/summoner/sitemaps"
 	"github.com/minio/minio-go/v7"
@@ -32,65 +35,71 @@ const robotsType = "robots"
 // ResourceURLs looks gets the resource URLs for a domain.  The results is a
 // map with domain name as key and []string of the URLs to process.
 func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB) (map[string][]string, error) {
-	m := make(map[string][]string) // make a map
+	domainsMap := make(map[string][]string)
 
 	// Know whether we are running in diff mode, in order to exclude urls that have already
 	// been summoned before
 	mcfg, err := configTypes.ReadSummmonerConfig(v1.Sub("summoner"))
-	domains, err := configTypes.GetSources(v1)
-	domains = configTypes.GetActiveSourceByHeadless(domains, headless)
+	sources, err := configTypes.GetSources(v1)
+	domains := configTypes.GetActiveSourceByHeadless(sources, headless)
 	if err != nil {
 		log.Println("Error getting sources to summon: ", err)
-		return m, err
+		return domainsMap, err
 	}
 
 	sitemapDomains := configTypes.GetActiveSourceByType(domains, siteMapType)
 
 	for _, domain := range sitemapDomains {
-		mapname := domain.Name
-		urls, err := getSitemapURLList(domain.URL)
+		robots, err := getRobotsForDomain(domain.Domain)
+
 		if err != nil {
-			log.Println("Error getting sitemap urls for: ", mapname, err)
-			return m, err
+			log.Printf("Error getting robots.txt for %s; continuing without it.", domain.Name)
+		}
+		urls, err := getSitemapURLList(domain.URL, robots)
+		if err != nil {
+			log.Println("Error getting sitemap urls for: ", domain.Name, err)
+			return domainsMap, err
 		}
 		if mcfg.Mode == "diff" {
-			urls = excludeAlreadySummoned(mapname, urls, db)
+			urls = excludeAlreadySummoned(domain.Name, urls, db)
 		}
-		m[mapname] = urls
-		log.Printf("%s sitemap size is : %d mode: %s \n", mapname, len(m[mapname]), mcfg.Mode)
+		overrideCrawlDelayFromRobots(v1, domain.Name, mcfg.Delay, robots)
+		domainsMap[domain.Name] = urls
+		log.Printf("%s sitemap size is : %d mode: %s \n", domain.Name, len(domainsMap[domain.Name]), mcfg.Mode)
 	}
 
 	robotsDomains := configTypes.GetActiveSourceByType(domains, robotsType)
 
 	for _, domain := range robotsDomains {
-		mapname := domain.Name
+
 		var urls []string
 		// first, get the robots file and parse it
 		robots, err := getRobotsTxt(domain.URL)
 		if err != nil {
-			log.Println("Error getting sitemap location from robots.txt for: ", mapname, err)
-			return m, err
+			log.Println("Error getting sitemap location from robots.txt for: ", domain.Name, err)
+			return domainsMap, err
 		}
 		for _, sitemap := range robots.Sitemaps() {
-			sitemapUrls, err := getSitemapURLList(sitemap)
+			sitemapUrls, err := getSitemapURLList(sitemap, robots)
 			if err != nil {
-				log.Println("Error getting sitemap urls for: ", mapname, err)
-				return m, err
+				log.Println("Error getting sitemap urls for: ", domain.Name, err)
+				return domainsMap, err
 			}
 			urls = append(urls, sitemapUrls...)
 		}
 		if mcfg.Mode == "diff" {
-			urls = excludeAlreadySummoned(mapname, urls, db)
+			urls = excludeAlreadySummoned(domain.Name, urls, db)
 		}
-		m[mapname] = urls
-		log.Printf("%s sitemap size from robots.txt is : %d mode: %s \n", mapname, len(m[mapname]), mcfg.Mode)
+		overrideCrawlDelayFromRobots(v1, domain.Name, mcfg.Delay, robots)
+		domainsMap[domain.Name] = urls
+		log.Printf("%s sitemap size from robots.txt is : %d mode: %s \n", domain.Name, len(domainsMap[domain.Name]), mcfg.Mode)
 	}
 
-	return m, nil
+	return domainsMap, nil
 }
 
 // given a sitemap url, parse it and get the list of URLS from it.
-func getSitemapURLList(domainURL string) ([]string, error) {
+func getSitemapURLList(domainURL string, robots *robotstxt.RobotsTxt) ([]string, error) {
 	var us sitemaps.Sitemap
 	var s []string
 
@@ -118,32 +127,54 @@ func getSitemapURLList(domainURL string) ([]string, error) {
 			}
 		}
 	}
-	// if mcfg["after"] != "" {
-	// 	//log.Println("Get After Date")
-	// 	us, err = sitemaps.GetAfterDate(domain.URL, nil, mcfg["after"])
-	// 	if err != nil {
-	// 		log.Println(domains[k].Name, err)
-	// 		// pass back error and deal with it better in the logs
-	// 		// and in the user experience
-	// 	}
-	// } else {
-	// 	//log.Println("Get with no date")
-	// 	us, err = sitemaps.Get(domains[k].URL, nil)
-	// 	if err != nil {
-	// 		log.Println(domains[k].Name, err)
-	// 		// pass back error and deal with it better in the logs
-	// 		// and in the user experience
-	// 	}
-	// }
 
 	// Convert the array of sitemap package struct to simply the URLs in []string
 	for _, urlStruct := range us.URL {
 		if urlStruct.Loc != "" { // TODO why did this otherwise add a nil to the array..  need to check
-			s = append(s, strings.TrimSpace(urlStruct.Loc))
+			loc := strings.TrimSpace(urlStruct.Loc)
+			loc = strings.ReplaceAll(loc, " ", "")
+			loc = strings.ReplaceAll(loc, "\n", "")
+
+			// only bother indexing urls that are allowed by robots.txt
+			if robots != nil {
+				allowed, err := robots.IsAllowed(EarthCubeAgent, loc)
+				if !allowed {
+					log.Printf("Declining to index %s because it is disallowed by robots.txt. Error information, if any: %s", loc, err)
+					continue
+				}
+			}
+			s = append(s, loc)
 		}
 	}
 
 	return s, nil
+}
+
+func overrideCrawlDelayFromRobots(v1 *viper.Viper, sourceName string, delay int64, robots *robotstxt.RobotsTxt) {
+	// Look at the crawl delay from this domain's robots.txt, if we can, and one exists.
+	if robots != nil {
+		// this is a time.Duration, which is in nanoseconds, because of COURSE it is, but we want milliseconds
+		crawlDelay := int64(robots.CrawlDelay(EarthCubeAgent) / time.Millisecond)
+		log.Printf("Crawl Delay specified by robots.txt for %s: %d", sourceName, crawlDelay)
+
+		// If our default delay is less than what is set there, set a delay for this
+		// domain to respect the robots.txt setting.
+		if delay < crawlDelay {
+			v1.Set("sources."+sourceName+".delay", crawlDelay)
+		}
+	}
+}
+
+func getRobotsForDomain(url string) (*robotstxt.RobotsTxt, error) {
+	robotsUrl := url + "/robots.txt"
+
+	robots, err := getRobotsTxt(robotsUrl)
+	if err != nil {
+		log.Printf("error getting robots.txt for %s : %s  ", url, err)
+		return nil, err
+	}
+
+	return robots, nil
 }
 
 func excludeAlreadySummoned(domainName string, urls []string, db *bolt.DB) []string {

--- a/internal/summoner/acquire/resources.go
+++ b/internal/summoner/acquire/resources.go
@@ -168,6 +168,7 @@ func overrideCrawlDelayFromRobots(v1 *viper.Viper, sourceName string, delay int6
 				return
 			}
 			source.Delay = crawlDelay
+			v1.Set("sources", sources)
 		}
 	}
 }

--- a/internal/summoner/acquire/resources_test.go
+++ b/internal/summoner/acquire/resources_test.go
@@ -1,0 +1,70 @@
+package acquire
+
+import (
+    "github.com/spf13/viper"
+    "github.com/stretchr/testify/assert"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "time"
+)
+
+
+func TestGetRobotsForDomain(t *testing.T) {
+    var robots = `User-agent: *
+        Disallow: /cgi-bin
+        Disallow: /forms
+        Disallow: /api/gi-cat
+        Disallow: /rocs/archives-catalog
+        Crawl-delay: 10`
+
+    var robots2 = `User-agent: *
+        Crawl-delay: 5`
+
+    mux := http.NewServeMux()
+
+    mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, req *http.Request) {
+        w.Write([]byte(robots))
+    })
+    mux.HandleFunc("/test-robots.txt", func(w http.ResponseWriter, req *http.Request) {
+        w.Write([]byte(robots2))
+    })
+    // generate a test server so we can capture and inspect the request
+    testServer := httptest.NewServer(mux)
+    defer func() { testServer.Close() }()
+
+    conf := map[string]interface{}{
+        "sources": []map[string]string{
+            {"name": "test", "domain": testServer.URL},
+            {"name": "test-robots", "domain": testServer.URL, "url": testServer.URL + "/test-robots.txt", "sourcetype": "robots"},
+        },
+    }
+
+    var viper = viper.New()
+    for key, value := range conf {
+        viper.Set(key, value)
+    }
+
+    t.Run("It returns an object representing robots.txt when specified", func(t *testing.T) {
+        robots, err := getRobotsForDomain(viper, "test")
+        assert.NotNil(t, robots)
+        assert.Nil(t, err)
+        assert.Equal(t, time.Duration(10000000000), robots.CrawlDelay("*"))
+    })
+
+    t.Run("It returns nil if there is an error", func(t *testing.T) {
+        robots, err := getRobotsForDomain(viper, "bad-value")
+        assert.Nil(t, robots)
+        assert.NotNil(t, err)
+    })
+
+    t.Run("It uses the specified robots url instead of building one if the sources type is robots", func(t *testing.T) {
+        robots, err := getRobotsForDomain(viper, "test-robots")
+        assert.NotNil(t, robots)
+        assert.Nil(t, err)
+        assert.Equal(t, time.Duration(5000000000), robots.CrawlDelay("*"))
+    })
+}
+
+func TestOverrideCrawlDelayFromRobots(t *testing.T) {
+}

--- a/internal/summoner/acquire/resources_test.go
+++ b/internal/summoner/acquire/resources_test.go
@@ -1,70 +1,76 @@
 package acquire
 
 import (
-    "github.com/spf13/viper"
-    "github.com/stretchr/testify/assert"
-    "net/http"
-    "net/http/httptest"
-    "testing"
-    "time"
+	"github.com/samclarke/robotstxt"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
 )
 
-
 func TestGetRobotsForDomain(t *testing.T) {
-    var robots = `User-agent: *
+	var robots = `User-agent: *
         Disallow: /cgi-bin
         Disallow: /forms
         Disallow: /api/gi-cat
         Disallow: /rocs/archives-catalog
         Crawl-delay: 10`
 
-    var robots2 = `User-agent: *
-        Crawl-delay: 5`
+	mux := http.NewServeMux()
 
-    mux := http.NewServeMux()
+	mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(robots))
+	})
+	// generate a test server so we can capture and inspect the request
+	testServer := httptest.NewServer(mux)
+	defer func() { testServer.Close() }()
 
-    mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, req *http.Request) {
-        w.Write([]byte(robots))
-    })
-    mux.HandleFunc("/test-robots.txt", func(w http.ResponseWriter, req *http.Request) {
-        w.Write([]byte(robots2))
-    })
-    // generate a test server so we can capture and inspect the request
-    testServer := httptest.NewServer(mux)
-    defer func() { testServer.Close() }()
+	t.Run("It returns an object representing robots.txt when specified", func(t *testing.T) {
+		robots, err := getRobotsForDomain(testServer.URL)
+		assert.NotNil(t, robots)
+		assert.Nil(t, err)
+		assert.Equal(t, time.Duration(10000000000), robots.CrawlDelay("*"))
+	})
 
-    conf := map[string]interface{}{
-        "sources": []map[string]string{
-            {"name": "test", "domain": testServer.URL},
-            {"name": "test-robots", "domain": testServer.URL, "url": testServer.URL + "/test-robots.txt", "sourcetype": "robots"},
-        },
-    }
-
-    var viper = viper.New()
-    for key, value := range conf {
-        viper.Set(key, value)
-    }
-
-    t.Run("It returns an object representing robots.txt when specified", func(t *testing.T) {
-        robots, err := getRobotsForDomain(viper, "test")
-        assert.NotNil(t, robots)
-        assert.Nil(t, err)
-        assert.Equal(t, time.Duration(10000000000), robots.CrawlDelay("*"))
-    })
-
-    t.Run("It returns nil if there is an error", func(t *testing.T) {
-        robots, err := getRobotsForDomain(viper, "bad-value")
-        assert.Nil(t, robots)
-        assert.NotNil(t, err)
-    })
-
-    t.Run("It uses the specified robots url instead of building one if the sources type is robots", func(t *testing.T) {
-        robots, err := getRobotsForDomain(viper, "test-robots")
-        assert.NotNil(t, robots)
-        assert.Nil(t, err)
-        assert.Equal(t, time.Duration(5000000000), robots.CrawlDelay("*"))
-    })
+	t.Run("It returns nil if there is an error", func(t *testing.T) {
+		robots, err := getRobotsForDomain(testServer.URL + "/bad-value")
+		assert.Nil(t, robots)
+		assert.NotNil(t, err)
+	})
 }
 
 func TestOverrideCrawlDelayFromRobots(t *testing.T) {
+	conf := map[string]interface{}{
+		"sources": []map[string]string{
+			{"name": "test", "domain": "http://test.com"},
+		},
+	}
+
+	var viper = viper.New()
+	for key, value := range conf {
+		viper.Set(key, value)
+	}
+
+	robots, err := robotstxt.Parse(`User-agent: *
+        Disallow: /cgi-bin
+        Disallow: /forms
+        Disallow: /api/gi-cat
+        Disallow: /rocs/archives-catalog
+        Crawl-delay: 10`, "http://www.test.com/robots.txt")
+
+    assert.Nil(t, err)
+
+	t.Run("It does nothing if given a nil robots object", func(t *testing.T) {
+		overrideCrawlDelayFromRobots(v1, "test", 0, nil)
+		assert.Nil(t, v1.Get("sources.test.delay"))
+	})
+
+	t.Run("It handles trying to set the crawl delay for a source that does not exist", func(t *testing.T) {
+		overrideCrawlDelayFromRobots(v1, "foo", 0, robots)
+		assert.Nil(t, v1.Get("sources.test.delay"))
+		assert.Nil(t, v1.Get("sources.foo.delay"))
+
+	})
 }

--- a/internal/summoner/acquire/resources_test.go
+++ b/internal/summoner/acquire/resources_test.go
@@ -1,6 +1,7 @@
 package acquire
 
 import (
+	configTypes "github.com/gleanerio/gleaner/internal/config"
 	"github.com/samclarke/robotstxt"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,6 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
-    configTypes "github.com/gleanerio/gleaner/internal/config"
 )
 
 func TestGetRobotsForDomain(t *testing.T) {
@@ -61,34 +61,34 @@ func TestOverrideCrawlDelayFromRobots(t *testing.T) {
         Disallow: /rocs/archives-catalog
         Crawl-delay: 10`, "http://www.test.com/robots.txt")
 
-    assert.Nil(t, err)
+	assert.Nil(t, err)
 
 	t.Run("It does nothing if given a nil robots object", func(t *testing.T) {
 		overrideCrawlDelayFromRobots(viper, "test", 0, nil)
-        sources, err := configTypes.GetSources(viper)
-        source, err := configTypes.GetSourceByName(sources, "test")
-        assert.Nil(t, err)
-        assert.Equal(t, int64(0), source.Delay)
+		sources, err := configTypes.GetSources(viper)
+		source, err := configTypes.GetSourceByName(sources, "test")
+		assert.Nil(t, err)
+		assert.Equal(t, int64(0), source.Delay)
 	})
 
 	t.Run("It handles trying to set the crawl delay for a source that does not exist", func(t *testing.T) {
 		overrideCrawlDelayFromRobots(viper, "foo", 0, robots)
-        assert.Nil(t, err)
+		assert.Nil(t, err)
 	})
 
-    t.Run("It overrides the crawl delay if it is more than our default delay", func(t *testing.T) {
-        overrideCrawlDelayFromRobots(viper, "test", 9999, robots)
-        sources, err := configTypes.GetSources(viper)
-        source, err := configTypes.GetSourceByName(sources, "test")
-        assert.Nil(t, err)
-        assert.Equal(t, int64(10000), source.Delay)
-    })
+	t.Run("It overrides the crawl delay if it is more than our default delay", func(t *testing.T) {
+		overrideCrawlDelayFromRobots(viper, "test", 9999, robots)
+		sources, err := configTypes.GetSources(viper)
+		source, err := configTypes.GetSourceByName(sources, "test")
+		assert.Nil(t, err)
+		assert.Equal(t, int64(10000), source.Delay)
+	})
 
-    t.Run("It does not override the crawl delay if it is less than our default delay", func(t *testing.T) {
-        overrideCrawlDelayFromRobots(viper, "test", 10001, robots)
-        sources, err := configTypes.GetSources(viper)
-        source, err := configTypes.GetSourceByName(sources, "test")
-        assert.Nil(t, err)
-        assert.Equal(t, int64(10000), source.Delay)
-    })
+	t.Run("It does not override the crawl delay if it is less than our default delay", func(t *testing.T) {
+		overrideCrawlDelayFromRobots(viper, "test", 10001, robots)
+		sources, err := configTypes.GetSources(viper)
+		source, err := configTypes.GetSourceByName(sources, "test")
+		assert.Nil(t, err)
+		assert.Equal(t, int64(10000), source.Delay)
+	})
 }

--- a/internal/summoner/acquire/utils.go
+++ b/internal/summoner/acquire/utils.go
@@ -1,11 +1,11 @@
 package acquire
 
 import (
+	"fmt"
 	"github.com/samclarke/robotstxt"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
-	"fmt"
 )
 
 func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsTxt, error) {

--- a/internal/summoner/acquire/utils.go
+++ b/internal/summoner/acquire/utils.go
@@ -5,6 +5,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
+	"fmt"
 )
 
 func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsTxt, error) {
@@ -25,8 +26,7 @@ func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsTxt, error) {
 	}
 
 	if resp.StatusCode >= 400 {
-		log.Printf("Robots.txt unavailable at %s", robotsUrl)
-		return nil, nil
+		return nil, fmt.Errorf("Robots.txt unavailable at %s", robotsUrl)
 	}
 
 	defer resp.Body.Close()

--- a/internal/summoner/acquire/utils.go
+++ b/internal/summoner/acquire/utils.go
@@ -23,6 +23,12 @@ func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsTxt, error) {
 		log.Printf("error fetching robots.txt at %s : %s  ", robotsUrl, err)
 		return nil, err
 	}
+
+	if resp.StatusCode >= 400 {
+		log.Printf("Robots.txt unavailable at %s", robotsUrl)
+		return nil, nil
+	}
+
 	defer resp.Body.Close()
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/summoner/acquire/utils_test.go
+++ b/internal/summoner/acquire/utils_test.go
@@ -1,0 +1,13 @@
+package acquire
+
+import (
+    "github.com/spf13/viper"
+    "github.com/stretchr/testify/assert"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "time"
+)
+
+func TestGetRobotsTxt(t *testing.T) {
+}

--- a/internal/summoner/acquire/utils_test.go
+++ b/internal/summoner/acquire/utils_test.go
@@ -1,13 +1,41 @@
 package acquire
 
 import (
-    "github.com/spf13/viper"
-    "github.com/stretchr/testify/assert"
-    "net/http"
-    "net/http/httptest"
-    "testing"
-    "time"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
 )
 
 func TestGetRobotsTxt(t *testing.T) {
+    var robots = `User-agent: *
+        Disallow: /cgi-bin
+        Disallow: /forms
+        Disallow: /api/gi-cat
+        Disallow: /rocs/archives-catalog
+        Crawl-delay: 10`
+
+    mux := http.NewServeMux()
+
+    mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, req *http.Request) {
+        w.Write([]byte(robots))
+    })
+
+    // generate a test server so we can capture and inspect the request
+    testServer := httptest.NewServer(mux)
+    defer func() { testServer.Close() }()
+
+    t.Run("It returns an object representing robots.txt when specified", func(t *testing.T) {
+        robots, err := getRobotsTxt(testServer.URL + "/robots.txt")
+        assert.NotNil(t, robots)
+        assert.Nil(t, err)
+        assert.Equal(t, time.Duration(10000000000), robots.CrawlDelay("*"))
+    })
+
+    t.Run("It returns nil if there is no robots.txt at that url", func(t *testing.T) {
+        robots, err := getRobotsTxt(testServer.URL + "/404.txt")
+        assert.Nil(t, robots)
+        assert.NotNil(t, err)
+    })
 }

--- a/internal/summoner/acquire/utils_test.go
+++ b/internal/summoner/acquire/utils_test.go
@@ -9,33 +9,33 @@ import (
 )
 
 func TestGetRobotsTxt(t *testing.T) {
-    var robots = `User-agent: *
+	var robots = `User-agent: *
         Disallow: /cgi-bin
         Disallow: /forms
         Disallow: /api/gi-cat
         Disallow: /rocs/archives-catalog
         Crawl-delay: 10`
 
-    mux := http.NewServeMux()
+	mux := http.NewServeMux()
 
-    mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, req *http.Request) {
-        w.Write([]byte(robots))
-    })
+	mux.HandleFunc("/robots.txt", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(robots))
+	})
 
-    // generate a test server so we can capture and inspect the request
-    testServer := httptest.NewServer(mux)
-    defer func() { testServer.Close() }()
+	// generate a test server so we can capture and inspect the request
+	testServer := httptest.NewServer(mux)
+	defer func() { testServer.Close() }()
 
-    t.Run("It returns an object representing robots.txt when specified", func(t *testing.T) {
-        robots, err := getRobotsTxt(testServer.URL + "/robots.txt")
-        assert.NotNil(t, robots)
-        assert.Nil(t, err)
-        assert.Equal(t, time.Duration(10000000000), robots.CrawlDelay("*"))
-    })
+	t.Run("It returns an object representing robots.txt when specified", func(t *testing.T) {
+		robots, err := getRobotsTxt(testServer.URL + "/robots.txt")
+		assert.NotNil(t, robots)
+		assert.Nil(t, err)
+		assert.Equal(t, time.Duration(10000000000), robots.CrawlDelay("*"))
+	})
 
-    t.Run("It returns nil if there is no robots.txt at that url", func(t *testing.T) {
-        robots, err := getRobotsTxt(testServer.URL + "/404.txt")
-        assert.Nil(t, robots)
-        assert.NotNil(t, err)
-    })
+	t.Run("It returns nil if there is no robots.txt at that url", func(t *testing.T) {
+		robots, err := getRobotsTxt(testServer.URL + "/404.txt")
+		assert.Nil(t, robots)
+		assert.NotNil(t, err)
+	})
 }

--- a/tools/siteprovdiff/main.go
+++ b/tools/siteprovdiff/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/spf13/viper"
 	bolt "go.etcd.io/bbolt"
-
 )
 
 var viperVal string


### PR DESCRIPTION
The work here is as follows:

- Fix buggy behavior that happens when a robots.txt file cannot be fetched for a domain
- Allow robots.txt (and end users, if they want!) to set a source-level crawl delay
- Disable robots.txt delay checking and allow / disallow checking with a `--rude` flag