### PR TITLE
Swap out robots.txt library for a more maintained one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,8 @@ require (
 	github.com/boltdb/bolt v1.3.1
 	github.com/gleanerio/nabu v0.0.0-20220223141452-a01fa9352430
 	github.com/oxffaa/gopher-parse-sitemap v0.0.0-20191021113419-005d2eb1def4
-	github.com/samclarke/robotstxt v0.0.0-20171127213916-2817654b7988
 	github.com/sirupsen/logrus v1.8.1
+	github.com/temoto/robotstxt v1.1.2
 	github.com/tidwall/gjson v1.10.2
 	github.com/tidwall/sjson v1.2.3
 	github.com/utahta/go-openuri v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,6 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.1.0/go.mod h1:B/mN0msZuINBtQ1zZLEQcegFJJf9vnYIR88KRMEuODE=
-github.com/samclarke/robotstxt v0.0.0-20171127213916-2817654b7988 h1:zFAgZ1xCwUizjAl1AUz7aLBulEHoSv+ew+RffLCWhBA=
-github.com/samclarke/robotstxt v0.0.0-20171127213916-2817654b7988/go.mod h1:XvytvkE1sPYD7U4AZzyWVJOsVTZuIDqFq+R5KKwy0Q0=
 github.com/schollz/progressbar v1.0.0 h1:gbyFReLHDkZo8mxy/dLWMr+Mpb1MokGJ1FqCiqacjZM=
 github.com/schollz/progressbar v1.0.0/go.mod h1:/l9I7PC3L3erOuz54ghIRKUEFcosiWfLvJv+Eq26UMs=
 github.com/schollz/progressbar/v3 v3.8.3 h1:FnLGl3ewlDUP+YdSwveXBaXs053Mem/du+wr7XSYKl8=
@@ -536,6 +534,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tebeka/snowball v0.4.2/go.mod h1:4IfL14h1lvwZcp1sfXuuc7/7yCsvVffTWxWxCLfFpYg=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
+github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
+github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/gjson v1.10.2 h1:APbLGOM0rrEkd8WBw9C24nllro4ajFuJu0Sc9hRz8Bo=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -29,7 +29,7 @@ func ResRetrieve(v1 *viper.Viper, mc *minio.Client, m map[string][]string, db *b
 	// for each domain in getDomain and us this one here with a semaphore
 	// to control the loop?
 	for domain, urls := range m {
-		log.Info("Queuing URLs for", domain)
+		log.Info("Queuing URLs for ", domain)
 		go getDomain(v1, mc, urls, domain, &wg, db)
 	}
 
@@ -68,10 +68,10 @@ func getConfig(v1 *viper.Viper, sourceName string) (string, int, int64, error) {
 	if source.Delay != 0 && source.Delay > delay {
 		delay = source.Delay
 		tc = 1
-		log.Info("Crawl delay set to", delay, "for", sourceName)
+		log.Info("Crawl delay set to ", delay, " for ", sourceName)
 	}
 
-	log.Info("Thread count", tc, "delay", delay)
+	log.Info("Thread count ", tc, " delay ", delay)
 	return bucketName, tc, delay, nil
 }
 
@@ -88,7 +88,7 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 
 	bucketName, tc, delay, err := getConfig(v1, sourceName)
 	if err != nil {
-		log.Panic("Error reading config file", err)
+		log.Panic("Error reading config file ", err)
 	}
 
 	var client http.Client
@@ -126,7 +126,7 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 
 			resp, err := client.Do(req)
 			if err != nil {
-				log.Error("#", i, "error on", urlloc, err) // print an message containing the index (won't keep order)
+				log.Error("#", i, " error on ", urlloc, err) // print an message containing the index (won't keep order)
 				lwg.Done()                                 // tell the wait group that we be done
 				<-semaphoreChan
 				return
@@ -135,7 +135,7 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 
 			doc, err := goquery.NewDocumentFromResponse(resp)
 			if err != nil {
-				log.Error("#", i, "error on", urlloc, err) // print an message containing the index (won't keep order)
+				log.Error("#", i, " error on ", urlloc, err) // print an message containing the index (won't keep order)
 				lwg.Done()                                 // tell the wait group that we be done
 				<-semaphoreChan
 				return
@@ -152,14 +152,14 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 				log.Debug(urlloc, "as", contentTypeHeader)
 				jsonlds, err = addToJsonListIfValid(v1, jsonlds, doc.Text())
 				if err != nil {
-					log.Error("Error processing json response from", urlloc, err)
+					log.Error("Error processing json response from ", urlloc, err)
 				}
 				// look in the HTML page for <script type=application/ld+json>
 			} else {
 				doc.Find("script[type='application/ld+json']").Each(func(i int, s *goquery.Selection) {
 					jsonlds, err = addToJsonListIfValid(v1, jsonlds, s.Text())
 					if err != nil {
-						log.Error("Error processing script tag in", urlloc, err)
+						log.Error("Error processing script tag in ", urlloc, err)
 					}
 				})
 			}

--- a/internal/summoner/acquire/resources.go
+++ b/internal/summoner/acquire/resources.go
@@ -9,7 +9,7 @@ import (
 	configTypes "github.com/gleanerio/gleaner/internal/config"
 	bolt "go.etcd.io/bbolt"
 
-	"github.com/samclarke/robotstxt"
+	"github.com/temoto/robotstxt"
 
 	"github.com/gleanerio/gleaner/internal/summoner/sitemaps"
 	"github.com/minio/minio-go/v7"
@@ -50,18 +50,25 @@ func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB)
 	sitemapDomains := configTypes.GetActiveSourceByType(domains, siteMapType)
 
 	for _, domain := range sitemapDomains {
-		var robots *robotstxt.RobotsTxt
+		var robots *robotstxt.RobotsData
+		var group *robotstxt.Group
+
 		if v1.Get("rude") == true {
 			robots = nil
+			group = nil
 			log.Info("Rude indexing mode enabled; ignoring robots.txt.")
 		} else {
 			robots, err = getRobotsForDomain(domain.Domain)
 			if err != nil {
 				log.Error("Error getting robots.txt for", domain.Name, "continuing without it.")
 			}
+			robots = nil
+			group = nil
 		}
-
-		urls, err := getSitemapURLList(domain.URL, robots)
+		if robots != nil {
+			group = robots.FindGroup(EarthCubeAgent)
+		}
+		urls, err := getSitemapURLList(domain.URL, group)
 		if err != nil {
 			log.Error("Error getting sitemap urls for: ", domain.Name, err)
 			return domainsMap, err
@@ -69,7 +76,7 @@ func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB)
 		if mcfg.Mode == "diff" {
 			urls = excludeAlreadySummoned(domain.Name, urls, db)
 		}
-		overrideCrawlDelayFromRobots(v1, domain.Name, mcfg.Delay, robots)
+		overrideCrawlDelayFromRobots(v1, domain.Name, mcfg.Delay, group)
 		domainsMap[domain.Name] = urls
 		log.Debug(domain.Name, "sitemap size is :", len(domainsMap[domain.Name]), "mode:", mcfg.Mode)
 	}
@@ -85,8 +92,9 @@ func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB)
 			log.Error("Error getting sitemap location from robots.txt for: ", domain.Name, err)
 			return domainsMap, err
 		}
-		for _, sitemap := range robots.Sitemaps() {
-			sitemapUrls, err := getSitemapURLList(sitemap, robots)
+		group := robots.FindGroup(EarthCubeAgent)
+		for _, sitemap := range robots.Sitemaps {
+			sitemapUrls, err := getSitemapURLList(sitemap, group)
 			if err != nil {
 				log.Error("Error getting sitemap urls for: ", domain.Name, err)
 				return domainsMap, err
@@ -96,7 +104,7 @@ func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB)
 		if mcfg.Mode == "diff" {
 			urls = excludeAlreadySummoned(domain.Name, urls, db)
 		}
-		overrideCrawlDelayFromRobots(v1, domain.Name, mcfg.Delay, robots)
+		overrideCrawlDelayFromRobots(v1, domain.Name, mcfg.Delay, group)
 		domainsMap[domain.Name] = urls
 		log.Debug(domain.Name, "sitemap size from robots.txt is :", len(domainsMap[domain.Name]), "mode:", mcfg.Mode)
 	}
@@ -105,7 +113,7 @@ func ResourceURLs(v1 *viper.Viper, mc *minio.Client, headless bool, db *bolt.DB)
 }
 
 // given a sitemap url, parse it and get the list of URLS from it.
-func getSitemapURLList(domainURL string, robots *robotstxt.RobotsTxt) ([]string, error) {
+func getSitemapURLList(domainURL string, robots *robotstxt.Group) ([]string, error) {
 	var us sitemaps.Sitemap
 	var s []string
 
@@ -141,13 +149,9 @@ func getSitemapURLList(domainURL string, robots *robotstxt.RobotsTxt) ([]string,
 			loc = strings.ReplaceAll(loc, " ", "")
 			loc = strings.ReplaceAll(loc, "\n", "")
 
-			// only bother indexing urls that are allowed by robots.txt
-			if robots != nil {
-				allowed, err := robots.IsAllowed(EarthCubeAgent, loc)
-				if !allowed {
-					log.Error("Declining to index", loc, "because it is disallowed by robots.txt. Error information, if any:", err)
-					continue
-				}
+			if robots != nil && !robots.Test(loc) {
+				log.Error("Declining to index ", loc, " because it is disallowed by robots.txt. Error information, if any:", err)
+				continue
 			}
 			s = append(s, loc)
 		}
@@ -156,11 +160,11 @@ func getSitemapURLList(domainURL string, robots *robotstxt.RobotsTxt) ([]string,
 	return s, nil
 }
 
-func overrideCrawlDelayFromRobots(v1 *viper.Viper, sourceName string, delay int64, robots *robotstxt.RobotsTxt) {
+func overrideCrawlDelayFromRobots(v1 *viper.Viper, sourceName string, delay int64, robots *robotstxt.Group) {
 	// Look at the crawl delay from this domain's robots.txt, if we can, and one exists.
 	if robots != nil {
 		// this is a time.Duration, which is in nanoseconds, because of COURSE it is, but we want milliseconds
-		crawlDelay := int64(robots.CrawlDelay(EarthCubeAgent) / time.Millisecond)
+		crawlDelay := int64(robots.CrawlDelay / time.Millisecond)
 		log.Info("Crawl Delay specified by robots.txt for", sourceName, ":", crawlDelay)
 
 		// If our default delay is less than what is set there, set a delay for this
@@ -179,7 +183,7 @@ func overrideCrawlDelayFromRobots(v1 *viper.Viper, sourceName string, delay int6
 	}
 }
 
-func getRobotsForDomain(url string) (*robotstxt.RobotsTxt, error) {
+func getRobotsForDomain(url string) (*robotstxt.RobotsData, error) {
 	robotsUrl := url + "/robots.txt"
 	log.Info("Getting robots.txt from", robotsUrl)
 	robots, err := getRobotsTxt(robotsUrl)

--- a/internal/summoner/acquire/utils.go
+++ b/internal/summoner/acquire/utils.go
@@ -12,7 +12,7 @@ func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsData, error) {
 
 	req, err := http.NewRequest("GET", robotsUrl, nil)
 	if err != nil {
-		log.Error("error creating http request:", err)
+		log.Error("error creating http request: ", err)
 		return nil, err
 	}
 	req.Header.Set("User-Agent", EarthCubeAgent)
@@ -20,7 +20,7 @@ func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsData, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Error("error fetching robots.txt at", robotsUrl, err)
+		log.Error("error fetching robots.txt at ", robotsUrl, err)
 		return nil, err
 	}
 
@@ -32,7 +32,7 @@ func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsData, error) {
 
 	robots, err := robotstxt.FromResponse(resp)
 	if err != nil {
-		log.Error("error parsing robots.txt at", robotsUrl, err)
+		log.Error("error parsing robots.txt at ", robotsUrl, err)
 		return nil, err
 	}
 	return robots, nil

--- a/internal/summoner/acquire/utils.go
+++ b/internal/summoner/acquire/utils.go
@@ -2,13 +2,12 @@ package acquire
 
 import (
 	"fmt"
-	"github.com/samclarke/robotstxt"
 	log "github.com/sirupsen/logrus"
-	"io/ioutil"
+	"github.com/temoto/robotstxt"
 	"net/http"
 )
 
-func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsTxt, error) {
+func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsData, error) {
 	var client http.Client
 
 	req, err := http.NewRequest("GET", robotsUrl, nil)
@@ -30,17 +29,11 @@ func getRobotsTxt(robotsUrl string) (*robotstxt.RobotsTxt, error) {
 	}
 
 	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Error("error reading response for robots.txt at", robotsUrl, err)
-		return nil, err
-	}
 
-	robots, err := robotstxt.Parse(string(bodyBytes), robotsUrl)
+	robots, err := robotstxt.FromResponse(resp)
 	if err != nil {
 		log.Error("error parsing robots.txt at", robotsUrl, err)
 		return nil, err
 	}
-
 	return robots, nil
 }

--- a/internal/summoner/acquire/utils_test.go
+++ b/internal/summoner/acquire/utils_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 )
 
 func TestGetRobotsTxt(t *testing.T) {
@@ -30,7 +29,7 @@ func TestGetRobotsTxt(t *testing.T) {
 		robots, err := getRobotsTxt(testServer.URL + "/robots.txt")
 		assert.NotNil(t, robots)
 		assert.Nil(t, err)
-		assert.Equal(t, time.Duration(10000000000), robots.CrawlDelay("*"))
+		assert.False(t, robots.TestAgent("/cgi-bin/exploit", "*"))
 	})
 
 	t.Run("It returns nil if there is no robots.txt at that url", func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/gleanerio/gleaner/issues/90

That's what I get for going with the first thing I found that supported a crawl delay.

I also noticed that all of the log statements I was so excited about are weird to read because the log functions don't put spaces between their arguments, like some libraries do.

It's a 🤦‍♀️ kinda week, I guess, but now we can have a crawl delay AND `Disallow: ` in robots.txt.