### PR TITLE
#195 add End time, and write out after a source is complete

### DIFF
--- a/internal/common/stats.go
+++ b/internal/common/stats.go
@@ -9,9 +9,10 @@ import (
 )
 
 type RunStats struct {
-	mu        sync.Mutex
-	Date      time.Time
-	RepoStats map[string]*RepoStats
+	mu         sync.Mutex
+	Date       time.Time
+	StopReason string
+	RepoStats  map[string]*RepoStats
 }
 
 func NewRunStats() *RunStats {
@@ -93,7 +94,8 @@ func (c *RepoStats) Value(key string) int {
 func (c *RunStats) Output() string {
 	out := fmt.Sprintln("RunStats:")
 	out += fmt.Sprintf("  Start: %s\n", c.Date)
-	out += fmt.Sprintf("  Repositories:\n")
+	out += fmt.Sprintf("  Reason: %s\n", c.StopReason)
+	out += fmt.Sprintf("  Soruce:\n")
 	for name, repo := range c.RepoStats {
 
 		out += fmt.Sprintf("    - name: %s\n", name)
@@ -108,10 +110,10 @@ func (c *RunStats) Output() string {
 
 func (c *RepoStats) Output() string {
 	c.setEndTime()
-	out := fmt.Sprintln("RepoStats:")
+	out := fmt.Sprintln("SourceStats:")
 	out += fmt.Sprintf("  Start: %s\n", c.Start)
 	out += fmt.Sprintf("  End: %s\n", c.End)
-	out += fmt.Sprintf("  Repository:\n")
+	out += fmt.Sprintf("  Soruce:\n")
 
 	out += fmt.Sprintf("    - name: %s\n", c.Name)
 	for r, count := range c.counts {

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -191,6 +191,7 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 		}(i, sourceName)
 
 	}
+	common.RunRepoStatsOutput(repoStats, sourceName)
 }
 
 func FindJSONInResponse(v1 *viper.Viper, urlloc string, repologger *log.Logger, response *http.Response) ([]string, error) {

--- a/internal/summoner/acquire/api.go
+++ b/internal/summoner/acquire/api.go
@@ -147,4 +147,5 @@ func getAPISource(v1 *viper.Viper, mc *minio.Client, source configTypes.Sources,
 		status = <-responseStatusChan
 		i++
 	}
+	common.RunRepoStatsOutput(repoStats, source.Name)
 }

--- a/internal/summoner/acquire/headlessNG.go
+++ b/internal/summoner/acquire/headlessNG.go
@@ -52,6 +52,7 @@ func HeadlessNG(v1 *viper.Viper, mc *minio.Client, m map[string][]string, runSta
 				log.Error(m[k][i], "::", err)
 			}
 		}
+		common.RunRepoStatsOutput(r, k)
 
 	}
 

--- a/internal/summoner/summoner.go
+++ b/internal/summoner/summoner.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func runStatsOutput(runStats *common.RunStats) {
+func RunStatsOutput(runStats *common.RunStats) {
 	fmt.Print(runStats.Output())
 	const layout = "2006-01-02-15-04-05"
 	t := time.Now()
@@ -49,7 +49,7 @@ func Summoner(mc *minio.Client, v1 *viper.Viper) {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		runStatsOutput(runStats)
+		RunStatsOutput(runStats)
 		os.Exit(1)
 	}()
 
@@ -78,7 +78,7 @@ func Summoner(mc *minio.Client, v1 *viper.Viper) {
 	diff := et.Sub(st)
 	log.Info("Summoner end time:", et)
 	log.Info("Summoner run time:", diff.Minutes())
-	runStatsOutput(runStats)
+	RunStatsOutput(runStats)
 	// What do I need to the "run" prov
 	// the URLs indexed  []string
 	// the graph generated?  "version" the graph by the build date

--- a/internal/summoner/summoner.go
+++ b/internal/summoner/summoner.go
@@ -49,6 +49,7 @@ func Summoner(mc *minio.Client, v1 *viper.Viper) {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
+		runStats.StopReason = "User Interrupt or Fatal Error"
 		RunStatsOutput(runStats)
 		os.Exit(1)
 	}()
@@ -78,6 +79,7 @@ func Summoner(mc *minio.Client, v1 *viper.Viper) {
 	diff := et.Sub(st)
 	log.Info("Summoner end time:", et)
 	log.Info("Summoner run time:", diff.Minutes())
+	runStats.StopReason = "Complete"
 	RunStatsOutput(runStats)
 	// What do I need to the "run" prov
 	// the URLs indexed  []string


### PR DESCRIPTION
Source Stats written to a file repo-NAME-stats-TIME.log
when source completes

```
SourceStats:
  Start: 2023-05-12 17:12:17.413822 -0700 PDT m=+2.421417561
  End: 2023-05-12 17:12:20.254585 -0700 PDT m=+5.262235644
  Soruce:
    - name: magic
      SitemapCount: 4332 
      HeadlessServerError: 4332 
RunStats:
  Start: 2023-05-12 17:12:15.49566 -0700 PDT m=+0.503218646
  Reason: Complete
  Soruce:
    - name: magic
      Start: 2023-05-12 17:12:17.413822 -0700 PDT m=+2.421417561
      End: 2023-05-12 17:12:20.254794 -0700 PDT m=+5.262443979
      SitemapCount: 4332 
      HeadlessServerError: 4332 
```

and if stopped

```
RunStats:
  Start: 2023-05-12 17:12:59.1048 -0700 PDT m=+0.441176442
  Reason: User Interrupt or Fatal Error
  Soruce:
```