### PR TITLE
add back in region for AWS and GCP

### DIFF
--- a/docs/GleanerConfig.md
+++ b/docs/GleanerConfig.md
@@ -1,12 +1,31 @@
 # Gleaner Configuration file
 
-This assumes that you have a container stack running
+The Gleaner stack requires a set of supporting services for full operation.
 
+These are:
+
+* s3 store: Such as Minio, AWS S3 or Google Cloud Services
+* triple store: (optional) A graph database that supports RDF if you wish to load the harvestd JSON-LD data graphs for query
+* headless: (optional) A headless browser such as Chrome or Firefox for use in those cases where the JSON-LD is not not staticly in the page DOM, but rather called and inserted by javascript on page load.
+
+## Important Note regarding S3
+In the case of AWS S3, it is important to use the region specific version of the AWS API URL.  Such as;
+
+```yaml
+minio:
+address: s3.us-west-2.amazonaws.com
+port: 443
+ssl: true
+accesskey:
+secretkey:
+bucket: ec-geocodes
+region: us-west-2
 ```
-s3 store
-triple store
-headless
-```
+
+rather than _s3.amazonaws.com_.   This avoids an auth error that is raised when the region specifid is different
+than the default region in your AWS credentials file.
+
+
 ## Gleaner Configuration generation
 Files can be generated using glcon. Described in [README_CONFIGURE_Template](./README_Configure_Template.md)
 
@@ -24,6 +43,7 @@ minio:
   secretKey: worldsbestsecretkey
   ssl: false
   bucket: gleaner
+  region: us-west-2
 gleaner:
   runid: runX # this will be the bucket the output is placed in...
   summon: true # do we want to visit the web sites and pull down the files

--- a/internal/common/minio.go
+++ b/internal/common/minio.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+
 	log "github.com/sirupsen/logrus"
 
 	configTypes "github.com/gleanerio/gleaner/internal/config"
@@ -12,29 +13,51 @@ import (
 
 // MinioConnection Set up minio and initialize client
 func MinioConnection(v1 *viper.Viper) *minio.Client {
-	//mcfg := v1.GetStringMapString("minio")
 	mSub := v1.Sub("minio")
 	mcfg, err := configTypes.ReadMinioConfig(mSub)
 	if err != nil {
 		log.Panic("error when file minio key:", err)
 	}
-	endpoint := fmt.Sprintf("%s:%d", mcfg.Address, mcfg.Port)
-	accessKeyID := mcfg.Accesskey
-	secretAccessKey := mcfg.Secretkey
-	useSSL := mcfg.Ssl
-	// auth fails if a region is set in minioclient...
-	//	region := mcfg.Region
 
-	minioClient, err := minio.New(endpoint,
-		&minio.Options{Creds: credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
-			Secure: useSSL,
-			//			Region: region,
-		})
+	var endpoint, accessKeyID, secretAccessKey string
+	var useSSL bool
+
+	if mcfg.Port == 0 {
+		endpoint = fmt.Sprintf("%s", mcfg.Address)
+		accessKeyID = mcfg.Accesskey
+		secretAccessKey = mcfg.Secretkey
+		useSSL = mcfg.Ssl
+	} else {
+		endpoint = fmt.Sprintf("%s:%d", mcfg.Address, mcfg.Port)
+		accessKeyID = mcfg.Accesskey
+		secretAccessKey = mcfg.Secretkey
+		useSSL = mcfg.Ssl
+	}
+
+	var minioClient *minio.Client
+
+	// used this == "" trick to not set region if not present due to
+	// past issue of auth fails if a region is set in minioclient...
+	if mcfg.Region == "" {
+		log.Println("no region set")
+		minioClient, err = minio.New(endpoint,
+			&minio.Options{Creds: credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
+				Secure: useSSL,
+			})
+	} else {
+		log.Println("region set for GCS or AWS, may cause issues with minio")
+		region := mcfg.Region
+		minioClient, err = minio.New(endpoint,
+			&minio.Options{Creds: credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
+				Secure: useSSL,
+				Region: region,
+			})
+	}
 
 	// minioClient.SetCustomTransport(&http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}})
 	if err != nil {
 		log.Fatal(err)
 	}
-	// don't set region until you created the client
+
 	return minioClient
 }

--- a/internal/config/minio.go
+++ b/internal/config/minio.go
@@ -14,7 +14,7 @@ type Minio struct {
 	Accesskey string //`mapstructure:"MINIO_ACCESS_KEY"`
 	Secretkey string // `mapstructure:"MINIO_SECRET_KEY"`
 	Bucket    string
-	//	Region    string
+	Region    string
 }
 
 // auth fails if a region is set in minioclient...
@@ -26,7 +26,7 @@ var MinioTemplate = map[string]interface{}{
 		"secretkey": "",
 		"bucket":    "",
 		"ssl":       "false",
-		//		"region":    "us-east-1",
+		"region":    "",
 	},
 }
 
@@ -43,7 +43,7 @@ func ReadMinioConfig(minioSubtress *viper.Viper) (Minio, error) {
 	minioSubtress.BindEnv("secretkey", "MINIO_SECRET_KEY")
 	minioSubtress.BindEnv("secretkey", "MINIO_SECRET_KEY")
 	minioSubtress.BindEnv("bucket", "MINIO_BUCKET")
-	//	minioSubtress.BindEnv("region", "MINIO_REGION")
+	minioSubtress.BindEnv("region", "MINIO_REGION")
 	minioSubtress.AutomaticEnv()
 	// config already read. substree passed
 	err := minioSubtress.Unmarshal(&minioCfg)


### PR DESCRIPTION
@valentinedwv   I added back in support for REGION to support GCS and AWS which I need.  However, I noted the issue with Minio Auth in the comments, so I wrapped the settings so that it is not set for minio if no region is set.   I was able to get this to work with Minio, Google and AWS.   The setting for the minio block I used follow.  

Let me know what you think and if this works OK for you.  

For local minio
```yaml
minio:
  address: 192.168.202.114
  port: 49153
  accessKey: KET
  secretKey: SECRET
  ssl: false
  bucket: gleaner.oih
```

For Google
```yaml
minio:
  address: storage.googleapis.com
  port:
   accessKey: KET
  secretKey: SECRET
  ssl: true
  bucket: gleaner-oih
  region: US-CENTRAL1
```


For AWS
```yaml
minio:
  address: s3.amazonaws.com
  port:
  accessKey: KET
  secretKey: SECRET
  ssl: true
  bucket: gleaner.oih
  region: us-east-1
```