### PR TITLE
224 set passed source to active

### DIFF
--- a/cmd/gleaner/main.go
+++ b/cmd/gleaner/main.go
@@ -116,6 +116,7 @@ func main() {
 
 		for _, k := range domains {
 			if sourceVal == k.Name {
+				k.Active = true
 				tmp = append(tmp, k)
 			}
 		}


### PR DESCRIPTION
when --source is passed on the command line, if source is not active, then nothing is run.

Set to active. This allows for testing of non-active sources